### PR TITLE
Add Optional Handling to XCAssert Methods

### DIFF
--- a/IntrepidSwiftWisdom.podspec
+++ b/IntrepidSwiftWisdom.podspec
@@ -5,6 +5,7 @@ Pod::Spec.new do |s|
   s.description   = <<-DESC
                     A collection of extensions to the Swift Standard Library, written by the developers of Intrepid Pursuits.
                     DESC
+  s.frameworks    = "XCTest"
   s.homepage      = "https://github.com/IntrepidPursuits/swift-wisdom"
   s.license       = "MIT"
   s.authors       = { "Logan Wright" => "logan@intrepid.io" }

--- a/src/XCTest/XCTest+Optionals.swift
+++ b/src/XCTest/XCTest+Optionals.swift
@@ -1,0 +1,30 @@
+import Foundation
+import XCTest
+
+public func ip_XCTAssertEqualOptional<T: Any where T: Equatable>(@autoclosure expression1: () -> T?, @autoclosure expression2: () -> T?, _ message: String? = nil, file: String = __FILE__, line: UInt = __LINE__) {
+    let exp1 = expression1()
+    let exp2 = expression2()
+    switch (exp1, exp2) {
+    case let (left?, right?):
+        XCTAssertEqual(left, right, message ?? "", file: file, line: line)
+    case (_?, _):
+        XCTFail(message ?? "exp1 != nil, exp2 == nil", file: file, line: line)
+    case (_, _?):
+        XCTFail(message ?? "exp1 == nil, exp2 != nil", file: file, line: line)
+    default: break
+    }
+}
+
+public func ip_XCTAssertEqualWithAccuracyOptional<T : FloatingPointType>(@autoclosure expression1: () -> T?, @autoclosure _ expression2: () -> T?, accuracy: T, _ message: String? = nil, file: String = __FILE__, line: UInt = __LINE__) {
+    let exp1 = expression1()
+    let exp2 = expression2()
+    switch (exp1, exp2) {
+    case let (left?, right?):
+        XCTAssertEqualWithAccuracy(left, right, accuracy: accuracy, message ?? "", file: file, line: line)
+    case (_?, _):
+        XCTFail(message ?? "exp1 != nil, exp2 == nil", file: file, line: line)
+    case (_, _?):
+        XCTFail(message ?? "exp1 == nil, exp2 != nil", file: file, line: line)
+    default: break
+    }
+}


### PR DESCRIPTION
Suppose you have two optionals, `value1` and `value2`, and you want to test their equality:

Calling `XCTAssertEqual(value1, value2)` is unsupported because `XCTAssertEqual` does not take optionals.

Calling `XCTAssertEqual(value1!, value2!)` is unsupported because unwrapping `value1` and `value2` will cause the test run stopping crash.

With these additions, calling `ip_XCTAssertEqualOptional(value1, value2)` will first check whether or not the optionals have a value, and it they do, it asserts the equality of their unwrapped values.
