### PR TITLE
adding umbrella podspec

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name          = "Intrepid"
+  s.version       = "0.1.3"
+  s.summary       = "Swift Bag"
+  s.description   = <<-DESC
+                    Collection of extensions and utility classes by and for the developers at intrepid pursuits.
+                    DESC
+  s.homepage      = "https://github.com/IntrepidPursuits/swift-wisdom"
+  s.license       = "MIT"
+  s.authors       = { "Intrepid Pursuits" => "logan@intrepid.io" }
+  s.social_media_url = 'https://twitter.com/itpd'
+  s.source        = { :git => "https://github.com/IntrepidPursuits/swift-wisdom.git", :tag => "#{s.version}" }
+  s.exclude_files = "tests/**/*"
+  s.platform      = :ios
+  s.ios.deployment_target = "8.0"
+  s.default_subspec = "Core"
+
+  s.subspec "Core" do |cs|
+    cs.source_files = "SwiftWisdom/Core/**/**/*.swift"
+    cs.dependency 'IP-UIKit-Wisdom', '0.0.9'
+  end
+end

--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.1.3"
+  s.version       = "0.1.6"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at intrepid pursuits.


### PR DESCRIPTION
I'd like to propose a new method of managing our pods, as of now, our two main collections are:

```
import IntrepidSwiftWisdom
import IP_UIKit_Wisdom
```

A lot of this is due to name spacing, but if we're going to make the decision to be public with these, and host them on the public repository, I think one simple `Intrepid` import will be nicer.  Once we own the namespace on cocoapods, as long as that is our choice of import, there will not be conflicts.

```
import Intrepid
```

Where it should live:

I'm proposing it live in swift wisdom for now, but potentially break out into its own library in the future

How do we control sub libraries:

We may be able to leverage subspecs, ie:

```
pod 'Intrepid/UIKit'
pod 'Intrepid/Video'
```

or just

```
pod 'Intrepid'
```

to default to more comprehensive coverage.

We might be able to leverage the new `@_exported import` to include sub libraries in our overall header.  ie: `import Intrepid` could import Swift Wisdom and UIKit Wisdom w/o requiring an explicit import.
## Issues

I think the main potential issue is bloat, but as of now, I don't see it as a problem to include a few extra unused files.  This could also be managed through subspecs for developers to opt in only to the classes they want.
