### PR TITLE
fixing overload causing ambiguous use of cell dequeing

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.2.1"
+  s.version       = "0.2.2"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at intrepid pursuits.

--- a/SwiftWisdom/Core/UIKit/CellConfiguring.swift
+++ b/SwiftWisdom/Core/UIKit/CellConfiguring.swift
@@ -31,11 +31,7 @@ public extension UICollectionView {
     
     // MARK: Register
 
-    public func ip_registerCell<T where T: UICollectionViewCell, T: TypeIdentifiable>(type: T.Type) {
-        return ip_registerCell(type, identifier: type.ip_identifier)
-    }
-
-    public func ip_registerCell<T where T: UICollectionViewCell, T: TypeIdentifiable>(_: T.Type, identifier: String) {
+    public func ip_registerCell<T where T: UICollectionViewCell, T: TypeIdentifiable>(_: T.Type, identifier: String = T.ip_identifier) {
         if let nib = T.ip_nib {
             registerNib(nib, forCellWithReuseIdentifier: identifier)
         } else {
@@ -84,10 +80,6 @@ public extension UICollectionView {
 public extension UITableView {
     
     // MARK: Register
-
-    public func ip_registerCell<T where T: UITableViewCell, T: TypeIdentifiable>(type: T.Type) {
-        return ip_registerCell(type, identifier: type.ip_identifier)
-    }
 
     public func ip_registerCell<T where T: UITableViewCell, T: TypeIdentifiable>(_: T.Type, identifier: String = T.ip_identifier) {
         if let nib = T.ip_nib {


### PR DESCRIPTION
The overload was making the default arguments behave weird and would cause `ambiguous use` 
