### PR TITLE
ip_updateFooter - Allows replacing a footerview's content after creation

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.5.0"
+  s.version       = "0.6.0"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at intrepid pursuits.

--- a/SwiftWisdom.xcodeproj/project.pbxproj
+++ b/SwiftWisdom.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		1C466C8F1C6E7A4500A709E8 /* CollectionTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C466C8E1C6E7A4500A709E8 /* CollectionTypeTests.swift */; };
 		1CE3D0681C6E61A500FB676C /* Mathable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE3D0671C6E61A500FB676C /* Mathable.swift */; };
 		1CE3D06B1C6E635F00FB676C /* MathableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE3D0691C6E628800FB676C /* MathableTests.swift */; };
+		317F2BD91D88547A009E793D /* UITableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317F2BD81D88547A009E793D /* UITableView+Extensions.swift */; };
 		8002059E1BF683E0005852C9 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8002059D1BF683E0005852C9 /* Result.swift */; };
 		800205A21BF684C7005852C9 /* NSDate+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800205A11BF684C7005852C9 /* NSDate+Comparable.swift */; };
 		800205A41BF684D1005852C9 /* TimeOfDay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800205A31BF684D1005852C9 /* TimeOfDay.swift */; };
@@ -113,6 +114,7 @@
 		1CE3D0691C6E628800FB676C /* MathableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MathableTests.swift; path = SwiftWisdomTests/MathableTests.swift; sourceTree = SOURCE_ROOT; };
 		2023F99068FFCFAB6FAD725D /* Pods_SwiftWisdomTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftWisdomTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2DD89A5540B26BFF3E2EB5A1 /* Pods-SwiftWisdomTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftWisdomTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftWisdomTests/Pods-SwiftWisdomTests.release.xcconfig"; sourceTree = "<group>"; };
+		317F2BD81D88547A009E793D /* UITableView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+Extensions.swift"; sourceTree = "<group>"; };
 		5DB8523DA54895EA38E762D8 /* Pods-SwiftWisdomTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftWisdomTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftWisdomTests/Pods-SwiftWisdomTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7F4534470A5614AE70AE5940 /* Pods-SwiftWisdom.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftWisdom.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftWisdom/Pods-SwiftWisdom.release.xcconfig"; sourceTree = "<group>"; };
 		8002059D1BF683E0005852C9 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Result.swift; path = CommonTypes/Result.swift; sourceTree = "<group>"; };
@@ -484,6 +486,7 @@
 				805807DE1C5BEDE400F9AFB1 /* UIImage+ColorImage.swift */,
 				805807E01C5BEE2300F9AFB1 /* UIImage+Overlay.swift */,
 				CD16463E1CC16A410049BBD5 /* UILabel+Typography.swift */,
+				317F2BD81D88547A009E793D /* UITableView+Extensions.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -830,6 +833,7 @@
 				80D63D0B1C4F1DF600C88D00 /* String+NSData.swift in Sources */,
 				80232C0A1BF2F1BD00818B6E /* UIView+GetConstraints.swift in Sources */,
 				1C0438C41C751F2100069CE1 /* BasicVerticalGradientLayer.swift in Sources */,
+				317F2BD91D88547A009E793D /* UITableView+Extensions.swift in Sources */,
 				FFCA61B61C8A259100FD35A7 /* String+EmailValidation.swift in Sources */,
 				8037D8731CADEE48008F324C /* Sequence+Utilities.swift in Sources */,
 				80232C041BF2F1BD00818B6E /* Array+Utilities.swift in Sources */,

--- a/SwiftWisdom/Core/UIKit/UITableView+Extensions.swift
+++ b/SwiftWisdom/Core/UIKit/UITableView+Extensions.swift
@@ -1,0 +1,26 @@
+//
+//  UITableView+Extensions.swift
+//  SwiftWisdom
+//
+//  Created by Alexander Persian on 9/8/16.
+//  Copyright © 2016 Intrepid. All rights reserved.
+//
+
+import UIKit
+
+extension UITableView {
+    /**
+     Allows you to dynamically update a tableview's footer after it has initally been drawn. (Width is not needed since footers are always the full width of the tableview)
+
+     - parameter footerView: View that will be used in the footer
+     - parameter height:     Height of the footer within the tableview
+     */
+    public func ip_updateFooter(withView view: UIView, ofHeight height: CGFloat) {
+        self.tableFooterView = nil // Ensure that old views are not left over or stacked on top of each other
+
+        let footerContainer = UIView(frame: CGRect(x: 0, y: 0, width: self.ip_width, height: height)) // Footers are always the width of the table view
+        self.tableFooterView = footerContainer
+        footerContainer.addSubview(view)
+        footerContainer.constrainViewToAllEdges(view)
+    }
+}


### PR DESCRIPTION
- Adds a method for dynamically updating a UITableViews footer after it has been initially created.
- This comes in handy when using a custom view within a table's footer that needs to change after creation.
