### PR TITLE
removes blue view, preventing crash on test runs

### DIFF
--- a/SwiftWisdom/Base.lproj/Main.storyboard
+++ b/SwiftWisdom/Base.lproj/Main.storyboard
@@ -1,40 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="SwiftWisdomDev" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ejx-VC-JA5">
-                                <rect key="frame" x="99" y="165" width="240" height="128"/>
-                                <color key="backgroundColor" red="0.2490495482" green="0.4741151757" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" red="0.2490495482" green="0.4741151757" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="128" id="jNm-Uk-gU0"/>
                                     <constraint firstAttribute="width" constant="240" id="xz3-DY-D9I"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Ejx-VC-JA5" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" constant="165" id="Y7P-n1-ZzT"/>
                             <constraint firstItem="Ejx-VC-JA5" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="99" id="Z5j-nq-kz1"/>
                         </constraints>
                     </view>
-                    <connections>
-                        <outlet property="blueView" destination="Ejx-VC-JA5" id="teE-1m-k3n"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/SwiftWisdom/ViewController.swift
+++ b/SwiftWisdom/ViewController.swift
@@ -9,22 +9,5 @@
 import UIKit
 
 class ViewController: UIViewController {
-    
-    @IBOutlet weak var blueView: UIView!
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        After(0.25) {
-            print("Hi")
-        }
-        // Do any additional setup after loading the view, typically from a nib.
-    }
-
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
-    }
-
 
 }
-


### PR DESCRIPTION
While updating to swift 3, NYC ran into an issue where the application would crash while running tests, claiming `ViewController is not key-value coding compliant for key "blueView"`. Removing the reference in the storyboard and `ViewController.swift` solved it for us, and I'm hoping to save anyone else the trouble. 
