### PR TITLE
Update Downloader to complete with failure if HTTP request was not success

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.6.2"
+  s.version       = "0.6.3"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at intrepid pursuits.

--- a/SwiftWisdom/Core/Downloader/Downloader.swift
+++ b/SwiftWisdom/Core/Downloader/Downloader.swift
@@ -15,6 +15,10 @@ public final class Downloader : NSObject, URLSessionDownloadDelegate {
         case inProgress(CGFloat)
         case completed(Result<URL>)
     }
+
+    public enum DownloaderError : Error {
+        case httpRequestFailed
+    }
     
     public let url: URL
     public let id = UUID().uuidString
@@ -52,6 +56,11 @@ public final class Downloader : NSObject, URLSessionDownloadDelegate {
     // MARK: NSURLSessionDownloadDelegate
     
     public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        if let httpResponse = downloadTask.response as? HTTPURLResponse, !httpResponse.isSuccess {
+            updater?(.completed(.failure(DownloaderError.httpRequestFailed)))
+            return
+        }
+
         updater?(.completed(.success(location)))
         updater = nil
     }
@@ -84,5 +93,11 @@ extension Downloader {
 
     public static func != (lhs: Downloader, rhs: Downloader) -> Bool {
         return !(lhs == rhs)
+    }
+}
+
+extension HTTPURLResponse {
+    public var isSuccess: Bool {
+        return 200...299 ~= statusCode
     }
 }

--- a/SwiftWisdom/Core/Downloader/Downloader.swift
+++ b/SwiftWisdom/Core/Downloader/Downloader.swift
@@ -58,10 +58,9 @@ public final class Downloader : NSObject, URLSessionDownloadDelegate {
     public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         if let httpResponse = downloadTask.response as? HTTPURLResponse, !httpResponse.isSuccess {
             updater?(.completed(.failure(DownloaderError.httpRequestFailed)))
-            return
+        } else {
+            updater?(.completed(.success(location)))
         }
-
-        updater?(.completed(.success(location)))
         updater = nil
     }
     


### PR DESCRIPTION
- Added a check to `URLSession(session: NSURLSession, downloadTask: NSURLSessionDownloadTask, didFinishDownloadingToURL location: NSURL)` to ensure that the updater state only gets success if the HTTP response was also success. Otherwise, send an `HTTPRequestFailed` error to the updater.
- This provides an error to handle if the URL is invalid or if there is a server error 
- Swift 3 version of earlier PR