### PR TITLE
Updated Coverage and Build Status images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](http://ci.intrepid.io:8080/buildStatus/icon?job=Swift Wisdom)](http://ci.intrepid.io:8080/job/Swift%20Wisdom/)
-[![Coverage](http://ci.intrepid.io:9913/jenkins/cobertura/Swift%20Wisdom/)](http://ci.intrepid.io:8080/job/Swift%20Wisdom/cobertura/)
+[![Build Status](https://ci.intrepid.io/buildStatus/icon?job=Swift-Wisdom)](https://ci.intrepid.io/job/Swift-Wisdom/)
+[![Coverage](http://ci.intrepid.io:9913/jenkins/cobertura/Swift-Wisdom/)](https://ci.intrepid.io/job/Swift-Wisdom/cobertura/)
 
 This library is meant to be a general grab bag of Swift methods made by the engineers at IntrepidPursuits.  As this library goes, useful components will be isolated into separate podspecs where appropriate.
 


### PR DESCRIPTION
The coverage and build status badges were pointing at the old CI server and using an old project name. These were updated so badges appear correctly again.