### PR TITLE
Fix TimeOfDay tests that fail in all timezones besides EST

### DIFF
--- a/SwiftWisdomTests/CommonTypes/ResultTests.swift
+++ b/SwiftWisdomTests/CommonTypes/ResultTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class ResultTests: XCTestCase {
     fileprivate enum ResultError: Error { case error }
     private final let successfulResult = Result<Int>.success(1)
-    private final let failureResult = Result<Any?>.failure(ResultError.error)
+    private final let failureResult = Result<Any>.failure(ResultError.error)
     
     func testSuccessResult() {
         XCTAssert(successfulResult.isSuccess)

--- a/SwiftWisdomTests/StandardLibrary/Date/TimeOfDayTests.swift
+++ b/SwiftWisdomTests/StandardLibrary/Date/TimeOfDayTests.swift
@@ -17,7 +17,7 @@ final class TimeOfDayTests: XCTestCase {
     private var testDoubleHourDigitEpochTime: TimeInterval = 1483268400
     
     override func setUp() {
-        let offset = TimeZone.current.secondsFromGMT()
+        let offset = TimeZone.autoupdatingCurrent.secondsFromGMT(for: Date(timeIntervalSince1970: testSingleHourDigitEpochTime)) // Was breaking on Daylight savings time.
         testSingleHourDigitEpochTime -= TimeInterval(offset)
         testDoubleHourDigitEpochTime -= TimeInterval(offset)
     }


### PR DESCRIPTION
These tests started failing on the build server (on the east coast) after daylight savings time stared.