### PR TITLE
ip_safely subscripting strings

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.7.4"
+  s.version       = "0.7.5"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.

--- a/SwiftWisdom/Core/StandardLibrary/String/String+Indexing.swift
+++ b/SwiftWisdom/Core/StandardLibrary/String/String+Indexing.swift
@@ -15,21 +15,31 @@ extension String {
     }
 
     /// Returns a substring in the given range.
-    /// If the range is beyond the string's length, returns the original string.
+    /// If the range is beyond the string's length, returns the substring up to it's bounds.
     public subscript(ip_safely range: Range<Int>) -> String {
         let chars = Array(characters)
-        guard range.upperBound < chars.count else { return self }
-        let substringCharacters = chars[range]
-        return String(substringCharacters)
+        if range.lowerBound < 0 {
+            return self[ip_safely: 0..<range.upperBound]
+        } else if range.upperBound > chars.count {
+            let newRange = range.lowerBound..<chars.count
+            return String(chars[newRange])
+        } else {
+            return String(chars[range])
+        }
     }
 
     /// Returns a substring in the given range.
-    /// If the range is beyond the string's length, returns the original string.
+    /// If the range is beyond the string's length, returns the substring up to it's bounds.
     public subscript(ip_safely range: CountableClosedRange<Int>) -> String {
         let chars = Array(characters)
-        guard range.upperBound < chars.count else { return self }
-        let substringCharacters = chars[range]
-        return String(substringCharacters)
+        if range.lowerBound < 0 {
+            return self[ip_safely: 0...range.upperBound]
+        } else if range.upperBound >= chars.count {
+            let newRange = range.lowerBound...(chars.count - 1)
+            return String(chars[newRange])
+        } else {
+            return String(chars[range])
+        }
     }
 
     public mutating func ip_dropFirst() {

--- a/SwiftWisdom/Core/StandardLibrary/String/String+Indexing.swift
+++ b/SwiftWisdom/Core/StandardLibrary/String/String+Indexing.swift
@@ -14,6 +14,24 @@ extension String {
         return String(substringCharacters)
     }
 
+    /// Returns a substring in the given range.
+    /// If the range is beyond the string's length, returns the original string.
+    public subscript(ip_safely range: Range<Int>) -> String {
+        let chars = Array(characters)
+        guard range.upperBound < chars.count else { return self }
+        let substringCharacters = chars[range]
+        return String(substringCharacters)
+    }
+
+    /// Returns a substring in the given range.
+    /// If the range is beyond the string's length, returns the original string.
+    public subscript(ip_safely range: CountableClosedRange<Int>) -> String {
+        let chars = Array(characters)
+        guard range.upperBound < chars.count else { return self }
+        let substringCharacters = chars[range]
+        return String(substringCharacters)
+    }
+
     public mutating func ip_dropFirst() {
         guard !isEmpty else { return }
         self = self[1..<characters.count]

--- a/SwiftWisdomTests/StandardLibrary/String/String+IndexingTests.swift
+++ b/SwiftWisdomTests/StandardLibrary/String/String+IndexingTests.swift
@@ -53,6 +53,8 @@ class String_IndexingTests: XCTestCase {
         XCTAssert(hello[ip_safely: 0...4] == "Hello")
         XCTAssert(hello[ip_safely: 0...3] == "Hell")
         XCTAssert(hello[ip_safely: 0...5] == "Hello")
+        XCTAssert(hello[ip_safely: 1...5] == "ello")
+        XCTAssert(hello[ip_safely: -1...5] == "Hello")
     }
 
     func testSafeRange() {
@@ -60,6 +62,8 @@ class String_IndexingTests: XCTestCase {
         XCTAssert(hello[ip_safely: 0..<5] == "Hello")
         XCTAssert(hello[ip_safely: 0..<4] == "Hell")
         XCTAssert(hello[ip_safely: 0..<6] == "Hello")
+        XCTAssert(hello[ip_safely: 1..<6] == "ello")
+        XCTAssert(hello[ip_safely: -1..<6] == "Hello")
     }
 }
 

--- a/SwiftWisdomTests/StandardLibrary/String/String+IndexingTests.swift
+++ b/SwiftWisdomTests/StandardLibrary/String/String+IndexingTests.swift
@@ -47,6 +47,20 @@ class String_IndexingTests: XCTestCase {
         emptyString.ip_dropFirst()
         XCTAssert(emptyString.isEmpty)
     }
+
+    func testSafeCountableClosedRange() {
+        let hello = "Hello"
+        XCTAssert(hello[ip_safely: 0...4] == "Hello")
+        XCTAssert(hello[ip_safely: 0...3] == "Hell")
+        XCTAssert(hello[ip_safely: 0...5] == "Hello")
+    }
+
+    func testSafeRange() {
+        let hello = "Hello"
+        XCTAssert(hello[ip_safely: 0..<5] == "Hello")
+        XCTAssert(hello[ip_safely: 0..<4] == "Hell")
+        XCTAssert(hello[ip_safely: 0..<6] == "Hello")
+    }
 }
 
 


### PR DESCRIPTION
Returns a substring in the given range.
If the range is beyond the string's length, returns a substring up to the bounds of the string.
For example:
```
let hello = "Hello"
hello[ip_safely: 1...5] // "ello"
hello[ip_safely: -1...3] // "Hell"
```