### PR TITLE
DataConvertible fix for 9.3

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.7.7"
+  s.version       = "0.7.8"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.

--- a/SwiftWisdom/Core/Foundation/Data/Data+Extensions.swift
+++ b/SwiftWisdom/Core/Foundation/Data/Data+Extensions.swift
@@ -16,12 +16,13 @@ extension Data {
         guard self.count > 0 else { return nil }
         return map { String(format: "%02hhx", $0) }.joined()
     }
+
+    // MARK: Convenience
     
     // From here: http://stackoverflow.com/questions/38023838/round-trip-swift-number-types-to-from-data
-    public func to<T>(type: T.Type) -> T? {
+    public func to<T: DataConvertible>(type: T.Type) -> T? {
         guard self.count > 0 else { return nil }
-        let value: T = self.withUnsafeBytes { $0.pointee }
-        return value
+        return T(ip_data: self)
     }
     
     public var ip_hexInt: UInt? {

--- a/SwiftWisdom/Core/Foundation/Data/Data+Extensions.swift
+++ b/SwiftWisdom/Core/Foundation/Data/Data+Extensions.swift
@@ -19,7 +19,6 @@ extension Data {
 
     // MARK: Convenience
     
-    // From here: http://stackoverflow.com/questions/38023838/round-trip-swift-number-types-to-from-data
     public func to<T: DataConvertible>(type: T.Type) -> T? {
         guard self.count > 0 else { return nil }
         return T(ip_data: self)

--- a/SwiftWisdom/Core/Foundation/Data/DataConvertible.swift
+++ b/SwiftWisdom/Core/Foundation/Data/DataConvertible.swift
@@ -18,13 +18,24 @@ public protocol DataConvertible {
 extension DataConvertible {
     
     public init?(ip_data data: Data) {
-        guard data.count == MemoryLayout<Self>.size else { return nil }
-        self = data.withUnsafeBytes { $0.pointee }
+        let size = MemoryLayout<Self>.size
+        if data.count < size {
+            let difference = size - data.count
+            var modifiedData = data
+            for _ in 0..<difference {
+                modifiedData.append(0)
+            }
+            self = modifiedData.withUnsafeBytes { $0.pointee }
+        } else if data.count == size {
+            self = data.withUnsafeBytes { $0.pointee }
+        } else {
+            return nil
+        }
     }
     
     public var ip_data: Data {
-        var value = self
-        return Data(buffer: UnsafeBufferPointer(start: &value, count: 1))
+        var copy = self
+        return Data(bytes: &copy, count: MemoryLayout<Self>.size)
     }
 }
 
@@ -36,4 +47,8 @@ extension Int8: DataConvertible {}
 extension Int16: DataConvertible {}
 extension Int32: DataConvertible {}
 extension Int64: DataConvertible {}
-// UnsignedIntegers are covered by UnsignedInteger+Extensions.swift (without optional init)
+extension UInt: DataConvertible {}
+extension UInt8: DataConvertible {}
+extension UInt16: DataConvertible {}
+extension UInt32: DataConvertible {}
+extension UInt64: DataConvertible {}

--- a/SwiftWisdom/Core/Foundation/Data/DataConvertible.swift
+++ b/SwiftWisdom/Core/Foundation/Data/DataConvertible.swift
@@ -20,11 +20,8 @@ extension DataConvertible {
     public init?(ip_data data: Data) {
         let size = MemoryLayout<Self>.size
         if data.count < size {
-            let difference = size - data.count
-            var modifiedData = data
-            for _ in 0..<difference {
-                modifiedData.append(0)
-            }
+            let emptyBytes = Array<UInt8>(repeating: 0, count: (size - data.count))
+            let modifiedData = data + emptyBytes
             self = modifiedData.withUnsafeBytes { $0.pointee }
         } else if data.count == size {
             self = data.withUnsafeBytes { $0.pointee }

--- a/SwiftWisdom/Core/StandardLibrary/Numbers/UnsignedInteger+Extensions.swift
+++ b/SwiftWisdom/Core/StandardLibrary/Numbers/UnsignedInteger+Extensions.swift
@@ -27,18 +27,8 @@ public func random(inRange range: CountableClosedRange<Int>) -> Int {
 // TODO: write tests for this extension
 extension UnsignedInteger {
 
-    public init(ip_data: Data) {
-        let hexInt = ip_data.ip_hexInt ?? 0
-        self.init(ip_safely: hexInt)
-    }
-
     public func ip_containsBitMask(_ bitMask: Self) -> Bool {
         return (self & bitMask) == bitMask
-    }
-
-    public var ip_data: Data {
-        var copy = self
-        return Data(bytes: &copy, count: MemoryLayout<Self>.size)
     }
 
     /// Converts a bit mask into its given indexes. For example, `0b101` will return `[0,2]`

--- a/SwiftWisdomTests/BitMaskTests.swift
+++ b/SwiftWisdomTests/BitMaskTests.swift
@@ -34,9 +34,9 @@ class BitMaskTests: XCTestCase {
     }
     
     func testDataInitializer() {
-        let data = "0x1f".ip_dataFromHexadecimalString()!
-        let mask = UInt8(ip_data: data)
-        let hex = data.ip_hexInt!
+        let data = "1f".ip_dataFromHexadecimalString()!
+        let mask = UInt8(ip_data: data)!
+        let hex = data.ip_hexInt
         XCTAssert(hex == UInt(mask))
         
         let empty = Data()

--- a/SwiftWisdomTests/Data/DataConversionTests.swift
+++ b/SwiftWisdomTests/Data/DataConversionTests.swift
@@ -133,6 +133,15 @@ class DataConversionTests: XCTestCase {
         let numberString = "321".data(using: String.Encoding.ascii)!
         XCTAssert((numberString as Data).ip_asciiString == "321")
     }
+
+    func testIntSmallValue() {
+        let intData = Data(bytes: [25])
+        XCTAssert(intData.ip_intValue == 25)
+        XCTAssert(intData.ip_int64Value == 25)
+
+        let intDataTwo = Data(bytes: [4,5]) // 0000_0101_0000_0100
+        XCTAssert(intDataTwo.ip_intValue == 1284)
+    }
     
     // MARK: Testing DataConvertible protocol
     
@@ -140,14 +149,20 @@ class DataConversionTests: XCTestCase {
         let data = Int8(-42).ip_data
         let backToNum = Int8(ip_data: data)
         XCTAssert(backToNum == -42)
+
+        let longData = Data(bytes: [4,5,6,7])
+        XCTAssertNil(Int8(ip_data: longData))
     }
     
     func testInt64Conversion() {
         let data = Int64(-4232).ip_data
         let backToNum = Int64(ip_data: data)
         XCTAssert(backToNum == -4232)
+
+        let longData = Data(bytes: [4,5,6,7,8,9,10,11,12,13,14])
+        XCTAssertNil(Int64(ip_data: longData))
     }
-    
+
     func testIntegerConversion() {
         let data = Int(-100055).ip_data // Be careful with the signed bit boundary.
         let backToNum = Int(ip_data: data)

--- a/SwiftWisdomTests/StandardLibrary/Numbers/Double+ExtensionsTests.swift
+++ b/SwiftWisdomTests/StandardLibrary/Numbers/Double+ExtensionsTests.swift
@@ -12,7 +12,7 @@ import SwiftWisdom
 class DoubleTests: XCTestCase {
 
     func testRounding() {
-        let unroundedDoubles = [M_PI, 5.0156, 10.014, 9999.99499]
+        let unroundedDoubles = [Double.pi, 5.0156, 10.014, 9999.99499]
         let roundedToOneDecimalPlaces = [3.1, 5.0, 10.0, 10000.0]
         let roundedToTwoDecimalPlaces = [3.14, 5.02, 10.01, 9999.99]
         let roundedToFiveDecimalPlaces = [3.14159, 5.0156, 10.014, 9999.99499]


### PR DESCRIPTION
As of Swift 3.1, the conversion from Data to Int64 broke on iOS 9.3 (http://stackoverflow.com/questions/43099577/withunsafebytes-with-swift-3-1-and-ios-9-3)

- I've addressed this by adding on the empty bytes manually during the conversion process. And funneling all Data to Number conversions through DataConvertible.
- Also fixed one last `.pi`