### PR TITLE
Updating RxSwift

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.7.8"
+  s.version       = "0.7.9"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - IP-UIKit-Wisdom (0.0.9)
-  - RxCocoa (3.0.1):
-    - RxSwift (~> 3.0)
-  - RxSwift (3.0.1)
-  - RxTest (3.1.0):
-    - RxSwift (~> 3.0)
+  - IP-UIKit-Wisdom (0.0.10)
+  - RxCocoa (3.4.0):
+    - RxSwift (~> 3.4)
+  - RxSwift (3.4.0)
+  - RxTest (3.4.0):
+    - RxSwift (~> 3.4)
 
 DEPENDENCIES:
   - IP-UIKit-Wisdom
@@ -13,11 +13,11 @@ DEPENDENCIES:
   - RxTest (~> 3.0)
 
 SPEC CHECKSUMS:
-  IP-UIKit-Wisdom: cd9838571e97427a0c61c05d856eaaca9afd7c1a
-  RxCocoa: 15a52fc590dcc700cb4a690a633b5c5184ce3a78
-  RxSwift: af5680055c4ad04480189c52d28385b1029493a6
-  RxTest: 661e33b5022682961784da03cf79c175fcc4bd64
+  IP-UIKit-Wisdom: b395a065344071b33659e5f6b918043a97c48a44
+  RxCocoa: d14ef6b6029e1ddc6e966508c09289090de68ff9
+  RxSwift: 3789a1af753002a14edecdb698a2424624296a9c
+  RxTest: beb6beb882cf1dcac5fc9fdbd4760a5254e7f3a6
 
 PODFILE CHECKSUM: 911a320307fdef2a400530396eb0ee1b029be56b
 
-COCOAPODS: 1.1.1
+COCOAPODS: 1.2.0

--- a/SwiftWisdom/Rx/Rx+Extensions.swift
+++ b/SwiftWisdom/Rx/Rx+Extensions.swift
@@ -24,11 +24,11 @@ infix operator <- : Binding
 infix operator >>> : Disposing
 
 public func <- <T: ObserverType, O: ObservableType>(observer: T, observable: O) -> Disposable where T.E == O.E {
-    return observable.observeOn(MainScheduler.instance).bindTo(observer)
+    return observable.observeOn(MainScheduler.instance).bind(to: observer)
 }
 
 public func <- <T: ObserverType, O: ObservableType>(observer: T, observable: O) -> Disposable where T.E == O.E? {
-    return observable.observeOn(MainScheduler.instance).bindTo(observer)
+    return observable.observeOn(MainScheduler.instance).bind(to: observer)
 }
 
 public func <- <T: ObserverType, O>(observer: T, variable: Variable<O>) -> Disposable where T.E == O {
@@ -40,7 +40,7 @@ public func <- <T: ObserverType, O>(observer: T, variable: Variable<O>) -> Dispo
 }
 
 public func <- <T, O: ObservableType>(variable: Variable<T>, observable: O) -> Disposable where O.E == T {
-    return observable.bindTo(variable)
+    return observable.bind(to: variable)
 }
 
 public func <- <T>(observer: Variable<T>, observable: Variable<T>) -> Disposable {
@@ -64,7 +64,7 @@ public func >>> (disposable: Disposable, compositeDisposable: CompositeDisposabl
 public func <-> <T>(property: ControlProperty<T>, variable: Variable<T>) -> Disposable {
     let bindToUIDisposable = variable
         .asObservable()
-        .bindTo(property)
+        .bind(to: property)
     let bindToVariable = property
         .subscribe(
             onNext: { n in

--- a/SwiftWisdomTests/Rx/Rx+DelayElementsTests.swift
+++ b/SwiftWisdomTests/Rx/Rx+DelayElementsTests.swift
@@ -30,7 +30,7 @@ final class RxDelayElementsTests: XCTestCase {
                 scheduler: scheduler
             )
         let observer = scheduler.createObserver(Int.self)
-        observable.bindTo(observer) >>> bag
+        observable.bind(to: observer) >>> bag
         scheduler.start()
 
         let correctEvents: [Recorded<Event<Int>>] = [
@@ -62,7 +62,7 @@ final class RxDelayElementsTests: XCTestCase {
                 scheduler: scheduler
             )
         let observer = scheduler.createObserver(Int.self)
-        observable.bindTo(observer) >>> bag
+        observable.bind(to: observer) >>> bag
         scheduler.start()
 
         let correctEvents: [Recorded<Event<Int>>] = [

--- a/SwiftWisdomTests/Rx/Rx+RepeatingTimeoutsTests.swift
+++ b/SwiftWisdomTests/Rx/Rx+RepeatingTimeoutsTests.swift
@@ -34,7 +34,7 @@ final class RxRepeatingTimeoutsTests: XCTestCase {
                 scheduler: scheduler
             )
         let observer = scheduler.createObserver(TestElement.self)
-        observable.bindTo(observer) >>> bag
+        observable.bind(to: observer) >>> bag
         scheduler.start()
 
         let correctEvents: [Recorded<Event<TestElement>>] = [


### PR DESCRIPTION
- Use `bind(to:)` in rxswift 3.4
This change was spurred on by cocoapods' Trunk complaints: 
```
Validating podspec
 -> Intrepid (0.7.8)
    - WARN  | [Intrepid/Rx] xcodebuild:  Intrepid/SwiftWisdom/Rx/Rx+Extensions.swift:27:57: warning: 'bindTo' is deprecated: renamed to 'bind(to:)'
    - NOTE  | [Intrepid/Rx] xcodebuild:  Intrepid/SwiftWisdom/Rx/Rx+Extensions.swift:27:57: note: use 'bind(to:)' instead
    - WARN  | [Intrepid/Rx] xcodebuild:  Intrepid/SwiftWisdom/Rx/Rx+Extensions.swift:31:57: warning: 'bindTo' is deprecated: renamed to 'bind(to:)'
    - NOTE  | [Intrepid/Rx] xcodebuild:  Intrepid/SwiftWisdom/Rx/Rx+Extensions.swift:31:57: note: use 'bind(to:)' instead
    - WARN  | [Intrepid/Rx] xcodebuild:  Intrepid/SwiftWisdom/Rx/Rx+Extensions.swift:43:23: warning: 'bindTo' is deprecated: renamed to 'bind(to:)'
    - NOTE  | [Intrepid/Rx] xcodebuild:  Intrepid/SwiftWisdom/Rx/Rx+Extensions.swift:43:23: note: use 'bind(to:)' instead
    - WARN  | [Intrepid/Rx] xcodebuild:  Intrepid/SwiftWisdom/Rx/Rx+Extensions.swift:67:10: warning: 'bindTo' is deprecated: renamed to 'bind(to:)'
    - NOTE  | [Intrepid/Rx] xcodebuild:  Intrepid/SwiftWisdom/Rx/Rx+Extensions.swift:67:10: note: use 'bind(to:)' instead
```