### PR TITLE
Addressing namespace collisions & String.characters deprecation

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,8 +7,8 @@ inhibit_all_warnings!
 
 def commonpods
   pod 'IP-UIKit-Wisdom'
-    pod 'RxSwift', '~> 4.0.0-beta.1'
-    pod 'RxCocoa', '~> 4.0.0-beta.1'
+    pod 'RxSwift', '~> 4.0.0-rc.0'
+    pod 'RxCocoa', '~> 4.0.0-rc.0'
 end
 
 target 'SwiftWisdom' do
@@ -17,7 +17,7 @@ end
 
 target 'SwiftWisdomTests' do
   commonpods()
-  pod 'RxTest', '~> 4.0.0-beta.1'
+  pod 'RxTest', '~> 4.0.0-rc.0'
 end
 
 post_install do |installer|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,23 +1,23 @@
 PODS:
   - IP-UIKit-Wisdom (0.0.10)
-  - RxCocoa (4.0.0-beta.1):
-    - RxSwift (~> 4.0.0-beta.1)
-  - RxSwift (4.0.0-beta.1)
-  - RxTest (4.0.0-beta.1):
-    - RxSwift (~> 4.0.0-beta.1)
+  - RxCocoa (4.0.0-rc.0):
+    - RxSwift (~> 4.0.0-rc.0)
+  - RxSwift (4.0.0-rc.0)
+  - RxTest (4.0.0-rc.0):
+    - RxSwift (~> 4.0.0-rc.0)
 
 DEPENDENCIES:
   - IP-UIKit-Wisdom
-  - RxCocoa (~> 4.0.0-beta.1)
-  - RxSwift (~> 4.0.0-beta.1)
-  - RxTest (~> 4.0.0-beta.1)
+  - RxCocoa (~> 4.0.0-rc.0)
+  - RxSwift (~> 4.0.0-rc.0)
+  - RxTest (~> 4.0.0-rc.0)
 
 SPEC CHECKSUMS:
   IP-UIKit-Wisdom: b395a065344071b33659e5f6b918043a97c48a44
-  RxCocoa: ca6cc0f4453145d90002d80df8f9c83dd8fb7338
-  RxSwift: 29f07e0e72cc5b40f146c64cc520ea6a6a0c73e9
-  RxTest: 56fcfdb52108edb20eea5ed662a3cdd6c6f55b3f
+  RxCocoa: 62457355be73369670fbdf053a79a491552b64ed
+  RxSwift: 1dd09ceb11531c39adff4efe23556b1484e16967
+  RxTest: 9c731f05da986e443a064e6c5c012ae3dc08c8b8
 
-PODFILE CHECKSUM: 9f73c5139ca6fc1388ea99d6cd21e12e9aed96e2
+PODFILE CHECKSUM: 063823ed351063eebfbce1260c44280569d0ec09
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.4.0.beta.1

--- a/SwiftWisdom/Core/CommonTypes/Multicast.swift
+++ b/SwiftWisdom/Core/CommonTypes/Multicast.swift
@@ -22,20 +22,20 @@ public struct Weak<T> where T: AnyObject {
 /**
     Conforming to this protocol lets a class implement a multi-delegate system.
 
-    Only subclasses of NSObject can conform to this protocol. In addition, you can only typealias `Delegate` to a
+    Only subclasses of NSObject can conform to this protocol. In addition, you can only typealias `MulticastDelegate` to a
     class or an `@objc` protocol.
  */
 public protocol Multicast: class {
 
-    associatedtype Delegate: AnyObject
+    associatedtype MulticastDelegate: AnyObject
 
-    var delegateReferences: [Weak<Delegate>] { get set }
+    var delegateReferences: [Weak<MulticastDelegate>] { get set }
 }
 
 public extension Multicast {
 
     /// Delegates of this class.
-    var delegates: [Delegate] {
+    var delegates: [MulticastDelegate] {
         let existing = delegateReferences.flatMap { $0.weak }
         if existing.count != delegateReferences.count {
             delegateReferences = existing.map { Weak($0) }
@@ -45,21 +45,21 @@ public extension Multicast {
 
     /**
         Add a delegate.
-     
-        - parameter delegate: Delegate to be added.
+
+        - parameter delegate: MulticastDelegate to be added.
      */
-    func add(delegate: Delegate) {
+    func add(delegate: MulticastDelegate) {
         remove(delegate: delegate)
         delegateReferences.append(Weak(delegate))
     }
 
     /**
         Remove delegates matching a predicate.
-     
+
         - parameter shouldRemove: A predicate that is called once for each delegate of this class. It should return true
           if a delegate should be removed.
      */
-    func removeDelegates(_ shouldRemove: (Delegate) -> Bool) {
+    func removeDelegates(_ shouldRemove: (MulticastDelegate) -> Bool) {
         delegateReferences = delegates
             .filter { !shouldRemove($0) }
             .map { Weak($0) }
@@ -68,9 +68,9 @@ public extension Multicast {
     /**
         Remove a delegate.
 
-        - parameter delegate: Delegate to be removed.
+        - parameter delegate: MulticastDelegate to be removed.
      */
-    func remove(delegate: Delegate) {
+    func remove(delegate: MulticastDelegate) {
         removeDelegates { $0 === delegate }
     }
 }

--- a/SwiftWisdom/Core/StandardLibrary/Dictionary/Dictionary+Utilities.swift
+++ b/SwiftWisdom/Core/StandardLibrary/Dictionary/Dictionary+Utilities.swift
@@ -50,8 +50,6 @@ extension Dictionary {
 
 private extension String {
     func ip_keypathComponents() -> [String] {
-        return characters
-            .split { $0 == "." }
-            .map { String($0) }
+        return split { $0 == "." }.map { String($0) }
     }
 }

--- a/SwiftWisdom/Core/StandardLibrary/String/String+Attributed.swift
+++ b/SwiftWisdom/Core/StandardLibrary/String/String+Attributed.swift
@@ -11,7 +11,7 @@ import UIKit
 public extension String {
     func ip_attributedStringWithSpacing(_ spacingValue: CGFloat) -> NSMutableAttributedString {
         let attributedString = NSMutableAttributedString(string: self)
-        attributedString.addAttribute(.kern, value: spacingValue, range: NSRange(location: 0, length: self.characters.count))
+        attributedString.addAttribute(.kern, value: spacingValue, range: NSRange(location: 0, length: self.count))
         return attributedString
     }
 }

--- a/SwiftWisdom/Core/StandardLibrary/String/String+Data.swift
+++ b/SwiftWisdom/Core/StandardLibrary/String/String+Data.swift
@@ -11,13 +11,13 @@ extension String {
         let clean = lowercased().replacingOccurrences(of: " ", with: "")
         let allowed = CharacterSet.alphanumerics
         let trimmed = clean.trimmingCharacters(in: allowed.inverted)
-        guard !trimmed.isEmpty && trimmed.characters.count.ip_isEven else { return nil }
+        guard !trimmed.isEmpty && trimmed.count.ip_isEven else { return nil }
 
         // everything ok, so now let's build the Data
 
-        var data = Data(capacity: trimmed.characters.count / 2)
+        var data = Data(capacity: trimmed.count / 2)
 
-        for i in stride(from: 0, through: trimmed.characters.count - 2, by: 2) {
+        for i in stride(from: 0, through: trimmed.count - 2, by: 2) {
             let byteString = trimmed[i...i + 1]
             var byte = UInt8(byteString.ip_hexInt)
             data.append(&byte, count: MemoryLayout<UInt8>.size)

--- a/SwiftWisdom/Core/StandardLibrary/String/String+Indexing.swift
+++ b/SwiftWisdom/Core/StandardLibrary/String/String+Indexing.swift
@@ -3,48 +3,55 @@ import Foundation
 extension String {
 
     public subscript(range: Range<Int>) -> String {
-        let chars = Array(characters)
-        let substringCharacters = chars[range]
-        return String(substringCharacters)
+        let lowerBound = index(startIndex, offsetBy: range.lowerBound)
+        let upperBound = index(startIndex, offsetBy: range.upperBound)
+        let indexRange = lowerBound..<upperBound
+        return String(self[indexRange])
+    }
+
+    public subscript(range: CountableRange<Int>) -> String {
+        let lowerBound = index(startIndex, offsetBy: range.lowerBound)
+        let upperBound = index(startIndex, offsetBy: range.upperBound)
+        let indexRange = lowerBound..<upperBound
+        return String(self[indexRange])
     }
 
     public subscript(range: CountableClosedRange<Int>) -> String {
-        let chars = Array(characters)
-        let substringCharacters = chars[range]
-        return String(substringCharacters)
+        let lowerBound = index(startIndex, offsetBy: range.lowerBound)
+        let upperBound = index(startIndex, offsetBy: range.upperBound)
+        let indexRange = lowerBound...upperBound
+        return String(self[indexRange])
     }
 
     /// Returns a substring in the given range.
     /// If the range is beyond the string's length, returns the substring up to it's bounds.
     public subscript(ip_safely range: Range<Int>) -> String {
-        let chars = Array(characters)
         if range.lowerBound < 0 {
             return self[ip_safely: 0..<range.upperBound]
-        } else if range.upperBound > chars.count {
-            let newRange = range.lowerBound..<chars.count
-            return String(chars[newRange])
+        } else if range.upperBound > self.count {
+            let newRange = range.lowerBound..<self.count
+            return String(self[newRange])
         } else {
-            return String(chars[range])
+            return String(self[range])
         }
     }
 
     /// Returns a substring in the given range.
     /// If the range is beyond the string's length, returns the substring up to it's bounds.
     public subscript(ip_safely range: CountableClosedRange<Int>) -> String {
-        let chars = Array(characters)
         if range.lowerBound < 0 {
             return self[ip_safely: 0...range.upperBound]
-        } else if range.upperBound >= chars.count {
-            let newRange = range.lowerBound...(chars.count - 1)
-            return String(chars[newRange])
+        } else if range.upperBound >= self.count {
+            let newRange = range.lowerBound...(self.count - 1)
+            return String(self[newRange])
         } else {
-            return String(chars[range])
+            return String(self[range])
         }
     }
 
     public mutating func ip_dropFirst() {
         guard !isEmpty else { return }
-        self = self[1..<characters.count]
+        self = self[1..<self.count]
     }
 
     /// From http://stackoverflow.com/questions/25138339/nsrange-to-rangestring-index/32379600#32379600

--- a/SwiftWisdom/Core/StandardLibrary/String/String+Indexing.swift
+++ b/SwiftWisdom/Core/StandardLibrary/String/String+Indexing.swift
@@ -24,12 +24,12 @@ extension String {
     }
 
     /// Returns a substring in the given range.
-    /// If the range is beyond the string's length, returns the substring up to it's bounds.
+    /// If the range is beyond the string's length, returns the substring up to its bounds.
     public subscript(ip_safely range: Range<Int>) -> String {
         if range.lowerBound < 0 {
             return self[ip_safely: 0..<range.upperBound]
-        } else if range.upperBound > self.count {
-            let newRange = range.lowerBound..<self.count
+        } else if range.upperBound > count {
+            let newRange = range.lowerBound..<count
             return String(self[newRange])
         } else {
             return String(self[range])
@@ -37,12 +37,12 @@ extension String {
     }
 
     /// Returns a substring in the given range.
-    /// If the range is beyond the string's length, returns the substring up to it's bounds.
+    /// If the range is beyond the string's length, returns the substring up to its bounds.
     public subscript(ip_safely range: CountableClosedRange<Int>) -> String {
         if range.lowerBound < 0 {
             return self[ip_safely: 0...range.upperBound]
-        } else if range.upperBound >= self.count {
-            let newRange = range.lowerBound...(self.count - 1)
+        } else if range.upperBound >= count {
+            let newRange = range.lowerBound...(count - 1)
             return String(self[newRange])
         } else {
             return String(self[range])
@@ -51,7 +51,7 @@ extension String {
 
     public mutating func ip_dropFirst() {
         guard !isEmpty else { return }
-        self = self[1..<self.count]
+        self = self[1..<count]
     }
 
     /// From http://stackoverflow.com/questions/25138339/nsrange-to-rangestring-index/32379600#32379600

--- a/SwiftWisdom/Core/StandardLibrary/String/String+Numbers.swift
+++ b/SwiftWisdom/Core/StandardLibrary/String/String+Numbers.swift
@@ -22,6 +22,6 @@ extension String {
     }
 
     public var ip_length: Int {
-        return self.count
+        return count
     }
 }

--- a/SwiftWisdom/Core/StandardLibrary/String/String+Numbers.swift
+++ b/SwiftWisdom/Core/StandardLibrary/String/String+Numbers.swift
@@ -22,6 +22,6 @@ extension String {
     }
 
     public var ip_length: Int {
-        return self.characters.count
+        return self.count
     }
 }

--- a/SwiftWisdom/Core/UIKit/UIColor+Hex.swift
+++ b/SwiftWisdom/Core/UIKit/UIColor+Hex.swift
@@ -14,7 +14,7 @@ public extension UIColor {
         if hex.hasPrefix("#") {
             cleanHex.ip_dropFirst()
         }
-        if cleanHex.characters.count != 6 {
+        if cleanHex.count != 6 {
             cleanHex = "FFFFFF"
         }
 


### PR DESCRIPTION
Updated Podfile. Updated `Delegate` to `MulticastDelegate` to avoid namespace collision issues. Addressed `String.characters` being deprecated