### PR TITLE
Point to RxSwift 4 release version

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.9.0"
+  s.version       = "0.9.1"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
 
   s.subspec "Rx" do |rx|
     rx.source_files = "SwiftWisdom/Rx/**/**/*.swift"
-    rx.dependency 'RxSwift', '~> 4.0.0-alpha'
-    rx.dependency 'RxCocoa', '~> 4.0.0-alpha'
+    rx.dependency 'RxSwift', '~> 4'
+    rx.dependency 'RxCocoa', '~> 4'
   end
 end

--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
 
   s.subspec "Rx" do |rx|
     rx.source_files = "SwiftWisdom/Rx/**/**/*.swift"
-    rx.dependency 'RxSwift', '~> 4'
-    rx.dependency 'RxCocoa', '~> 4'
+    rx.dependency 'RxSwift', '~> 4.0'
+    rx.dependency 'RxCocoa', '~> 4.0'
   end
 end

--- a/Podfile
+++ b/Podfile
@@ -7,8 +7,8 @@ inhibit_all_warnings!
 
 def commonpods
   pod 'IP-UIKit-Wisdom'
-    pod 'RxSwift', '~> 4'
-    pod 'RxCocoa', '~> 4'
+    pod 'RxSwift', '~> 4.0'
+    pod 'RxCocoa', '~> 4.0'
 end
 
 target 'SwiftWisdom' do
@@ -17,7 +17,7 @@ end
 
 target 'SwiftWisdomTests' do
   commonpods()
-  pod 'RxTest', '~> 4'
+  pod 'RxTest', '~> 4.0'
 end
 
 post_install do |installer|

--- a/Podfile
+++ b/Podfile
@@ -7,8 +7,8 @@ inhibit_all_warnings!
 
 def commonpods
   pod 'IP-UIKit-Wisdom'
-    pod 'RxSwift', '~> 4.0.0-rc.0'
-    pod 'RxCocoa', '~> 4.0.0-rc.0'
+    pod 'RxSwift', '~> 4'
+    pod 'RxCocoa', '~> 4'
 end
 
 target 'SwiftWisdom' do
@@ -17,7 +17,7 @@ end
 
 target 'SwiftWisdomTests' do
   commonpods()
-  pod 'RxTest', '~> 4.0.0-rc.0'
+  pod 'RxTest', '~> 4'
 end
 
 post_install do |installer|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,9 +8,9 @@ PODS:
 
 DEPENDENCIES:
   - IP-UIKit-Wisdom
-  - RxCocoa (~> 4)
-  - RxSwift (~> 4)
-  - RxTest (~> 4)
+  - RxCocoa (~> 4.0)
+  - RxSwift (~> 4.0)
+  - RxTest (~> 4.0)
 
 SPEC CHECKSUMS:
   IP-UIKit-Wisdom: b395a065344071b33659e5f6b918043a97c48a44
@@ -18,6 +18,6 @@ SPEC CHECKSUMS:
   RxSwift: fd680d75283beb5e2559486f3c0ff852f0d35334
   RxTest: 0041e792cede35e53e4749f378d21482af0e9d12
 
-PODFILE CHECKSUM: 2b0dbc6c81726e1b0c814514bc7db9c54643cd8b
+PODFILE CHECKSUM: d81cbe2f98140887848195204b8b667819be7198
 
 COCOAPODS: 1.3.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,23 +1,23 @@
 PODS:
   - IP-UIKit-Wisdom (0.0.10)
-  - RxCocoa (4.0.0-rc.0):
-    - RxSwift (~> 4.0.0-rc.0)
-  - RxSwift (4.0.0-rc.0)
-  - RxTest (4.0.0-rc.0):
-    - RxSwift (~> 4.0.0-rc.0)
+  - RxCocoa (4.0.0):
+    - RxSwift (~> 4.0)
+  - RxSwift (4.0.0)
+  - RxTest (4.0.0):
+    - RxSwift (~> 4.0)
 
 DEPENDENCIES:
   - IP-UIKit-Wisdom
-  - RxCocoa (~> 4.0.0-rc.0)
-  - RxSwift (~> 4.0.0-rc.0)
-  - RxTest (~> 4.0.0-rc.0)
+  - RxCocoa (~> 4)
+  - RxSwift (~> 4)
+  - RxTest (~> 4)
 
 SPEC CHECKSUMS:
   IP-UIKit-Wisdom: b395a065344071b33659e5f6b918043a97c48a44
-  RxCocoa: 62457355be73369670fbdf053a79a491552b64ed
-  RxSwift: 1dd09ceb11531c39adff4efe23556b1484e16967
-  RxTest: 9c731f05da986e443a064e6c5c012ae3dc08c8b8
+  RxCocoa: d62846ca96495d862fa4c59ea7d87e5031d7340e
+  RxSwift: fd680d75283beb5e2559486f3c0ff852f0d35334
+  RxTest: 0041e792cede35e53e4749f378d21482af0e9d12
 
-PODFILE CHECKSUM: 063823ed351063eebfbce1260c44280569d0ec09
+PODFILE CHECKSUM: 2b0dbc6c81726e1b0c814514bc7db9c54643cd8b
 
-COCOAPODS: 1.4.0.beta.1
+COCOAPODS: 1.3.1


### PR DESCRIPTION
Now that stable release of RxSwift 4 is out, this points to it.