### PR TITLE
TimeInterval to Measurement initializers and vice versa

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.9.1"
+  s.version       = "0.9.2"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.
@@ -18,7 +18,8 @@ Pod::Spec.new do |s|
                       "Alan Scarpa" => "alan@intrepid.io",
                       "Paul Rolfe" => "paul@intrepid.io",
                       "Colin Tan" => "ctan@intrepid.io",
-                      "Stephen Wingchi Wong" => "stephenwong@intrepid.io"
+                      "Stephen Wingchi Wong" => "stephenwong@intrepid.io",
+                      "Bob Gilmore" => "bgilmore@intrepid.io"
                     }
   s.social_media_url = 'https://twitter.com/intpd'
   s.source        = { :git => "https://github.com/IntrepidPursuits/swift-wisdom.git", :tag => "#{s.version}" }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ def xcodeProject = new io.intrepid.XcodeProject()
 xcodeProject.name = 'SwiftWisdom'
 xcodeProject.addBuild([ configuration: "Debug" ])
 xcodeProject.xcodeVersion = '9'
-xcodeProject.simulator = 'iPhone 7 (11.0)'
+xcodeProject.simulator = 'iPhone 7'
 
 def config = [
   deploy: false,

--- a/SwiftWisdom.xcodeproj/project.pbxproj
+++ b/SwiftWisdom.xcodeproj/project.pbxproj
@@ -51,6 +51,10 @@
 		31C0E33D1E15A9CB009AB216 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C0E33C1E15A9CB009AB216 /* UIViewController+Extensions.swift */; };
 		31C0E33F1E15AA72009AB216 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C0E33E1E15AA72009AB216 /* UIView+Extensions.swift */; };
 		31C0E3441E15C8D5009AB216 /* GeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C0E3431E15C8D5009AB216 /* GeometryTests.swift */; };
+		49688E801FFD2127008BE521 /* TimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49688E7F1FFD2127008BE521 /* TimeInterval+Extensions.swift */; };
+		49688E821FFD28A3008BE521 /* TimeIntervalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49688E811FFD28A3008BE521 /* TimeIntervalTests.swift */; };
+		49688E841FFD3CDA008BE521 /* Measurement+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49688E831FFD3CDA008BE521 /* Measurement+Extensions.swift */; };
+		49688E861FFD435C008BE521 /* MeasurementUnitDurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49688E851FFD435C008BE521 /* MeasurementUnitDurationTests.swift */; };
 		50D4C0475426EF5C6D884DA9 /* Pods_SwiftWisdomTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D78024964F38E35675660D1A /* Pods_SwiftWisdomTests.framework */; };
 		8002059E1BF683E0005852C9 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8002059D1BF683E0005852C9 /* Result.swift */; };
 		800205A21BF684C7005852C9 /* NSDate+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800205A11BF684C7005852C9 /* NSDate+Comparable.swift */; };
@@ -169,6 +173,10 @@
 		31C0E33C1E15A9CB009AB216 /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
 		31C0E33E1E15AA72009AB216 /* UIView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		31C0E3431E15C8D5009AB216 /* GeometryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeometryTests.swift; sourceTree = "<group>"; };
+		49688E7F1FFD2127008BE521 /* TimeInterval+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Extensions.swift"; sourceTree = "<group>"; };
+		49688E811FFD28A3008BE521 /* TimeIntervalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIntervalTests.swift; sourceTree = "<group>"; };
+		49688E831FFD3CDA008BE521 /* Measurement+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Measurement+Extensions.swift"; sourceTree = "<group>"; };
+		49688E851FFD435C008BE521 /* MeasurementUnitDurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementUnitDurationTests.swift; sourceTree = "<group>"; };
 		4E9D68BE066065C510CF97B7 /* Pods-SwiftWisdomTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftWisdomTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftWisdomTests/Pods-SwiftWisdomTests.release.xcconfig"; sourceTree = "<group>"; };
 		5EAF2031B1809BA087E2827D /* Pods-SwiftWisdom.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftWisdom.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftWisdom/Pods-SwiftWisdom.release.xcconfig"; sourceTree = "<group>"; };
 		703B104B32DD95D07A614A46 /* Pods-SwiftWisdomTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftWisdomTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftWisdomTests/Pods-SwiftWisdomTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -425,6 +433,8 @@
 			children = (
 				800205A11BF684C7005852C9 /* NSDate+Comparable.swift */,
 				319CB0E41E14502F00BBD79B /* Date+Extensions.swift */,
+				49688E831FFD3CDA008BE521 /* Measurement+Extensions.swift */,
+				49688E7F1FFD2127008BE521 /* TimeInterval+Extensions.swift */,
 				800205A31BF684D1005852C9 /* TimeOfDay.swift */,
 			);
 			path = Time;
@@ -735,6 +745,8 @@
 				CDCDE2581E67C574007B3784 /* NSDateComparableTests.swift */,
 				CDCDE25C1E67D785007B3784 /* TimeOfDayTests.swift */,
 				1CFEBD041E8047D60078108A /* DateFormattingTests.swift */,
+				49688E851FFD435C008BE521 /* MeasurementUnitDurationTests.swift */,
+				49688E811FFD28A3008BE521 /* TimeIntervalTests.swift */,
 			);
 			name = Date;
 			sourceTree = "<group>";
@@ -1034,6 +1046,7 @@
 				319CB0E31E144CF400BBD79B /* Bundle+Extensions.swift in Sources */,
 				80D63D241C4F231C00C88D00 /* Synchronize.swift in Sources */,
 				80232BFE1BF2F1BD00818B6E /* After.swift in Sources */,
+				49688E801FFD2127008BE521 /* TimeInterval+Extensions.swift in Sources */,
 				80232C0D1BF2FAA100818B6E /* AppDelegate.swift in Sources */,
 				80232BFF1BF2F1BD00818B6E /* Qu.swift in Sources */,
 				805807DF1C5BEDE400F9AFB1 /* UIImage+ColorImage.swift in Sources */,
@@ -1054,6 +1067,7 @@
 				1C99FB581DD51DEC009FC493 /* String+Data.swift in Sources */,
 				802C4BAF1C1A1C0200C69D80 /* PercentAnimator.swift in Sources */,
 				8037D8711CADEBAB008F324C /* RawRepresentable.swift in Sources */,
+				49688E841FFD3CDA008BE521 /* Measurement+Extensions.swift in Sources */,
 				80D63D061C4F1AC900C88D00 /* UIApplication+Extensions.swift in Sources */,
 				80232C0B1BF2F1BD00818B6E /* UIView+Nib.swift in Sources */,
 				E7E2576C1E3F99FF00CA3DBD /* Rx+DelayElements.swift in Sources */,
@@ -1096,6 +1110,7 @@
 				E69A8C811E4E5751004E0663 /* QuTests.swift in Sources */,
 				CDCDE2591E67C574007B3784 /* NSDateComparableTests.swift in Sources */,
 				13425F901DB0761500F446BE /* String+IndexingTests.swift in Sources */,
+				49688E821FFD28A3008BE521 /* TimeIntervalTests.swift in Sources */,
 				E67264821E9E780C00880794 /* XCTest+Optionals.swift in Sources */,
 				E7A613961E3FA2B6006382DA /* Rx+DelayElementsTests.swift in Sources */,
 				805807EC1C5D8B3C00F9AFB1 /* VersionTests.swift in Sources */,
@@ -1127,6 +1142,7 @@
 				314F3BF61E9EA7E7005753BE /* VideoPlayerTests.swift in Sources */,
 				80232BB81BF2EE2E00818B6E /* SwiftWisdomTests.swift in Sources */,
 				1CFEBD081E8055AB0078108A /* UIButtonTests.swift in Sources */,
+				49688E861FFD435C008BE521 /* MeasurementUnitDurationTests.swift in Sources */,
 				13425F961DB07D0000F446BE /* Array+UtilitiesTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftWisdom/AppDelegate.swift
+++ b/SwiftWisdom/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/SwiftWisdom/Core/Colors/ColorDescriptor.swift
+++ b/SwiftWisdom/Core/Colors/ColorDescriptor.swift
@@ -25,7 +25,7 @@ public enum ColorDescriptor {
     case hex(hex: String)
 }
 
-extension ColorDescriptor : ExpressibleByStringLiteral, RawRepresentable, Equatable {
+extension ColorDescriptor: ExpressibleByStringLiteral, RawRepresentable, Equatable {
     public typealias RawValue = StringLiteralType
     public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
     public typealias UnicodeScalarLiteralType = StringLiteralType

--- a/SwiftWisdom/Core/Controls/VideoPlayer.swift
+++ b/SwiftWisdom/Core/Controls/VideoPlayer.swift
@@ -69,7 +69,7 @@ extension Video {
 
 // MARK: Player
 
-public protocol VideoPlayerDelegate : class {
+public protocol VideoPlayerDelegate: class {
     /**
      The delegate is notified when the video finishes playing and returns 
      a boolean whether or not the video should repeat

--- a/SwiftWisdom/Core/Foundation/NSAttributedString/NSMutableAttributedString+Format.swift
+++ b/SwiftWisdom/Core/Foundation/NSAttributedString/NSMutableAttributedString+Format.swift
@@ -19,7 +19,7 @@ public extension NSMutableAttributedString {
      
      - returns: NSMutableAttributedString with the attributes applied to argument strings.
      */
-    convenience init(formatString: String, attributes: [NSAttributedStringKey : AnyObject], arguments: String...) {
+    convenience init(formatString: String, attributes: [NSAttributedStringKey: AnyObject], arguments: String...) {
         let arguments = arguments.map { NSAttributedString(string: $0, attributes: attributes) }
         self.init(string: formatString)
         ip_format(withArguments: arguments)
@@ -34,7 +34,7 @@ public extension NSMutableAttributedString {
 
      - returns: NSMutableAttributedString with the attributes applied to argument strings.
      */
-    convenience init(formatString string: String, attributes: [NSAttributedStringKey : AnyObject]?, arguments: [NSAttributedString]) {
+    convenience init(formatString string: String, attributes: [NSAttributedStringKey: AnyObject]?, arguments: [NSAttributedString]) {
         let mutable = NSMutableAttributedString(string: string, attributes: attributes)
         mutable.ip_format(withArguments: arguments)
         self.init(attributedString: mutable)

--- a/SwiftWisdom/Core/Foundation/Time/Measurement+Extensions.swift
+++ b/SwiftWisdom/Core/Foundation/Time/Measurement+Extensions.swift
@@ -1,0 +1,16 @@
+//
+//  Measurement+Extensions.swift
+//  SwiftWisdom
+//
+//  Created by Gilmore, R. on 1/3/18.
+//  Copyright © 2018 Intrepid. All rights reserved.
+//
+
+import Foundation
+
+@available(iOS 10.0, *)
+public extension Measurement where UnitType == UnitDuration {
+    init(value: TimeInterval) {
+        self.init(value: value, unit: UnitDuration.seconds)
+    }
+}

--- a/SwiftWisdom/Core/Foundation/Time/NSDate+Comparable.swift
+++ b/SwiftWisdom/Core/Foundation/Time/NSDate+Comparable.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // Date already conforms to comparable. But NSDate does not.
 
-extension NSDate : Comparable {
+extension NSDate: Comparable {
     @nonobjc public static func < (lhs: NSDate, rhs: NSDate) -> Bool {
         return lhs.timeIntervalSince1970 < rhs.timeIntervalSince1970
     }

--- a/SwiftWisdom/Core/Foundation/Time/TimeInterval+Extensions.swift
+++ b/SwiftWisdom/Core/Foundation/Time/TimeInterval+Extensions.swift
@@ -1,0 +1,16 @@
+//
+//  TimeInterval+Extensions.swift
+//  SwiftWisdom
+//
+//  Created by Bob Gilmore on 1/3/18.
+//  Copyright © 2018 Intrepid. All rights reserved.
+//
+
+import Foundation
+
+public extension TimeInterval {
+    @available(iOS 10.0, *)
+    init(_ duration: Measurement<UnitDuration>) {
+        self.init(duration.converted(to: .seconds).value)
+    }
+}

--- a/SwiftWisdom/Core/StandardLibrary/Dictionary/Dictionary+Utilities.swift
+++ b/SwiftWisdom/Core/StandardLibrary/Dictionary/Dictionary+Utilities.swift
@@ -16,8 +16,8 @@ extension Dictionary {
             self[first] = settable
         } else {
             let rejoined = keys.joined(separator: ".")
-            var subdict: [String : AnyObject] = [:]
-            if let sub = self[first] as? [String : AnyObject] {
+            var subdict: [String: AnyObject] = [:]
+            if let sub = self[first] as? [String: AnyObject] {
                 subdict = sub
             }
             subdict.ip_set(value: value, forKeypath: rejoined)
@@ -40,7 +40,7 @@ extension Dictionary {
         guard let first = keys.first as? Key else { print("Unable to use string as key on type: \(Key.self)"); return nil }
         guard let value = self[first] else { return nil }
         keys.remove(at: 0)
-        if !keys.isEmpty, let subDict = value as? [String : AnyObject] {
+        if !keys.isEmpty, let subDict = value as? [String: AnyObject] {
             let rejoined = keys.joined(separator: ".")
             return subDict.ip_value(forKeypath: rejoined)
         }

--- a/SwiftWisdom/Core/UIKit/UILabel+Typography.swift
+++ b/SwiftWisdom/Core/UIKit/UILabel+Typography.swift
@@ -39,7 +39,7 @@ extension UILabel {
         attributedText = attrText
     }
 
-    private func baseAttributes() -> [NSAttributedStringKey : AnyObject] {
+    private func baseAttributes() -> [NSAttributedStringKey: AnyObject] {
         return [.font : font, .foregroundColor : textColor]
     }
 

--- a/SwiftWisdom/Core/Version/Version.swift
+++ b/SwiftWisdom/Core/Version/Version.swift
@@ -118,14 +118,14 @@ extension Version: CustomStringConvertible {
 
 // MARK: Operator Overloads
 
-extension Version : Equatable {
+extension Version: Equatable {
     /// Metadata is considered when measuring equality.
     public static func == (lhs: Version, rhs: Version) -> Bool {
         return lhs.description == rhs.description
     }
 }
 
-extension Version : Comparable {
+extension Version: Comparable {
     /// Metadata is not considered when measuring precedence.
     public static func < (lhs: Version, rhs: Version) -> Bool {
         return lhs.comparableDescription.compare(rhs.comparableDescription, options: .numeric) == .orderedAscending

--- a/SwiftWisdomTests/StandardLibrary/MeasurementUnitDurationTests.swift
+++ b/SwiftWisdomTests/StandardLibrary/MeasurementUnitDurationTests.swift
@@ -1,0 +1,24 @@
+//
+//  MeasurementUnitDuration.swift
+//  SwiftWisdomTests
+//
+//  Created by Bob Gilmore on 1/3/18.
+//  Copyright © 2018 Intrepid. All rights reserved.
+//
+
+import XCTest
+
+class MeasurementUnitDurationTests: XCTestCase {
+    
+    private let secondsPerHour = 60.0 * 60.0
+
+    @available(iOS 10.0, *)
+    func testMeasurementTimeIntervalInitializer() {
+        let hours = 2.0
+        let interval = TimeInterval(hours * secondsPerHour)
+
+        let traditionalMeasurement = Measurement(value: hours, unit: UnitDuration.hours)
+        let timeIntervalMeasurement = Measurement(value: interval)
+        XCTAssertEqual(timeIntervalMeasurement, traditionalMeasurement)
+    }
+}

--- a/SwiftWisdomTests/StandardLibrary/TimeIntervalTests.swift
+++ b/SwiftWisdomTests/StandardLibrary/TimeIntervalTests.swift
@@ -1,0 +1,24 @@
+//
+//  TimeIntervalTests.swift
+//  SwiftWisdomTests
+//
+//  Created by Bob Gilmore on 1/3/18.
+//  Copyright © 2018 Intrepid. All rights reserved.
+//
+
+import XCTest
+import SwiftWisdom
+
+class TimeIntervalTests: XCTestCase {
+
+    private let secondsPerHour = 60.0 * 60.0
+    
+    @available(iOS 10.0, *)
+    func testTimeIntervalMeasurementInitializer() {
+        let hours = 2.0
+        let twoHourMeasurement = Measurement(value: hours, unit: UnitDuration.hours)
+        let intervalFromSeconds = TimeInterval(hours * secondsPerHour)
+        let intervalFromDuration = TimeInterval(twoHourMeasurement)
+        XCTAssertEqual(intervalFromDuration, intervalFromSeconds)
+    }
+}


### PR DESCRIPTION
In order to make time-based Measurement objects easier to
use, add initializers to convert between TimeIntervals and
Measurements.

This allows us to create Measurment objects that specify
their own units, pass them around in our code, and then
easily create TimeIntervals when needed to pass to APIs
that require them.