### PR TITLE
Alex/update to fix new xcode issues

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.9.3"
+  s.version       = "0.10.0"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.

--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.9.2"
+  s.version       = "0.9.3"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source        = { :git => "https://github.com/IntrepidPursuits/swift-wisdom.git", :tag => "#{s.version}" }
   s.exclude_files = "tests/**/*"
   s.platform      = :ios
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "9.0"
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
   s.default_subspec = "Core"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,8 @@
 def xcodeProject = new io.intrepid.XcodeProject()
 xcodeProject.name = 'SwiftWisdom'
 xcodeProject.addBuild([ configuration: "Debug" ])
-xcodeProject.xcodeVersion = '9'
-xcodeProject.simulator = 'iPhone 7'
+xcodeProject.xcodeVersion = '9.3'
+xcodeProject.simulator = 'iPhone 8'
 
 def config = [
   deploy: false,

--- a/SwiftWisdom.xcodeproj/project.pbxproj
+++ b/SwiftWisdom.xcodeproj/project.pbxproj
@@ -1231,7 +1231,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1278,7 +1278,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/SwiftWisdom/Core/Colors/ColorDescriptor.swift
+++ b/SwiftWisdom/Core/Colors/ColorDescriptor.swift
@@ -85,11 +85,11 @@ extension ColorDescriptor: ExpressibleByStringLiteral, RawRepresentable, Equatab
             // If any portion of the string has a `.`, we are in 0-1.0 scale
             if string.contains(".") {
                 let floats = rgbComponents
-                    .flatMap { Double($0) }
+                    .compactMap { Double($0) }
                     .map { CGFloat($0) }
                 self = .rgbFloat(r: floats[0], g: floats[1], b: floats[2], a: floats[3])
             } else {
-                let ints = rgbComponents.flatMap { Int($0) }
+                let ints = rgbComponents.compactMap { Int($0) }
                 self = .rgb255(r: ints[0], g: ints[1], b: ints[2], a: ints[3])
             }
         } else if string.hasPrefix("#") {

--- a/SwiftWisdom/Core/CommonTypes/Multicast.swift
+++ b/SwiftWisdom/Core/CommonTypes/Multicast.swift
@@ -36,7 +36,7 @@ public extension Multicast {
 
     /// Delegates of this class.
     var delegates: [MulticastDelegate] {
-        let existing = delegateReferences.flatMap { $0.weak }
+        let existing = delegateReferences.compactMap { $0.weak }
         if existing.count != delegateReferences.count {
             delegateReferences = existing.map { Weak($0) }
         }


### PR DESCRIPTION
Multiple issues were found when attempting to update the pod trunk after merging in PR #147.

These issues were caused by a few things:
- flatMap needed to switch to compactMap in three places (ref: https://github.com/apple/swift-evolution/blob/master/proposals/0187-introduce-filtermap.md)
- The podspec still showed support for iOS 8.0 which prevented the use of NSLayoutAnchors (pod spec linting failed)
- Our project file still showed support for Swift 2.3 in the main proj file, while the individual targets were flagged for 4.1 already.

The 0.9.2 tag has not been released to Cocoapods, but exists in the repo. This tag currently points to a broken version should anyone manually install the project and use Xcode 9.3 (Swift 4.1). After the PR is merged should the tag be rewritten to point to this commit (overwriting 0.9.2), or should that tag stay around?