### PR TITLE
Add operator binding support for BehaviorRelay

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.10.1"
+  s.version       = "0.10.2"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - IP-UIKit-Wisdom (0.0.10)
-  - RxCocoa (4.0.0):
+  - RxCocoa (4.1.2):
     - RxSwift (~> 4.0)
-  - RxSwift (4.0.0)
-  - RxTest (4.0.0):
+  - RxSwift (4.1.2)
+  - RxTest (4.1.2):
     - RxSwift (~> 4.0)
 
 DEPENDENCIES:
@@ -14,9 +14,9 @@ DEPENDENCIES:
 
 SPEC CHECKSUMS:
   IP-UIKit-Wisdom: b395a065344071b33659e5f6b918043a97c48a44
-  RxCocoa: d62846ca96495d862fa4c59ea7d87e5031d7340e
-  RxSwift: fd680d75283beb5e2559486f3c0ff852f0d35334
-  RxTest: 0041e792cede35e53e4749f378d21482af0e9d12
+  RxCocoa: d88ba0f1f6abf040011a9eb4b539324fc426843a
+  RxSwift: e49536837d9901277638493ea537394d4b55f570
+  RxTest: e634f15fd2c2cd0e0120132ef7a4f7be69ad0393
 
 PODFILE CHECKSUM: d81cbe2f98140887848195204b8b667819be7198
 

--- a/SwiftWisdomTests/Rx/Rx+ExtensionsTest.swift
+++ b/SwiftWisdomTests/Rx/Rx+ExtensionsTest.swift
@@ -62,5 +62,73 @@ class OperatorTests: XCTestCase {
         UILabel().rx.text <- observable >>> compositeDisposable
         XCTAssertEqual(1, compositeDisposable.count)
     }
+    
+    func testBehaviorRelayBinding() {
+        let disposeBag = DisposeBag()
+        let label = UILabel()
+        let behaviorRelay = BehaviorRelay<String?>(value: nil)
+        
+        label.rx.text <- behaviorRelay >>> disposeBag
+        XCTAssertEqual(nil, label.text)
+        
+        behaviorRelay.accept("hello")
+        XCTAssertEqual("hello", label.text)
+        
+        behaviorRelay.accept(nil)
+        XCTAssertEqual(nil, label.text)
+    }
+    
+    func testNonOptionalBehaviorRelayBindingToOptionalObserver() {
+        let disposeBag = DisposeBag()
+        let label = UILabel()
+        let behaviorRelay = BehaviorRelay<String>(value: "")
+
+        label.rx.text <- behaviorRelay >>> disposeBag
+        XCTAssertEqual("", label.text)
+        
+        behaviorRelay.accept("hello")
+        XCTAssertEqual("hello", label.text)
+    }
+    
+    func testBindingToBehaviorRelay() {
+        let disposeBag = DisposeBag()
+        let sut = BehaviorRelay<String>(value: "")
+        let behaviorRelay = BehaviorRelay<String>(value: "hello")
+
+        sut <- behaviorRelay >>> disposeBag
+        XCTAssertEqual(behaviorRelay.value, sut.value)
+        XCTAssertEqual("hello", sut.value)
+
+        behaviorRelay.accept("world")
+        XCTAssertEqual(behaviorRelay.value, sut.value)
+    }
+    
+    func testTwoWayBindingWithBehaviorRelay() {
+        let disposeBag = DisposeBag()
+        let textField = UITextField()
+        let behaviorRelay = BehaviorRelay<String?>(value: nil)
+
+        textField.rx.text <-> behaviorRelay >>> disposeBag
+        behaviorRelay.accept("hello")
+        XCTAssertEqual("hello", textField.text)
+        
+        textField.text = "world"
+        textField.sendActions(for: .editingChanged)
+        XCTAssertEqual("world", behaviorRelay.value)
+    }
+    
+    func testTwoWayBindingWithVariable() {
+        let disposeBag = DisposeBag()
+        let textField = UITextField()
+        let variable = Variable<String?>(nil)
+        
+        textField.rx.text <-> variable >>> disposeBag
+        variable.value = "hello"
+        XCTAssertEqual("hello", textField.text)
+        
+        textField.text = "world"
+        textField.sendActions(for: .editingChanged)
+        XCTAssertEqual("world", variable.value)
+    }
 
 }


### PR DESCRIPTION
* Updates RxSwift, RxCocoa, and RxTest versions from 4.0.0 to 4.1.2
* Adds operator binding support `->`, `<->`, `>>>` for `BehaviorRelay` in RxCocoa