### PR TITLE
Allow DirectoryManager to use search paths other than "Documents"

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.10.0"
+  s.version       = "0.10.1"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.

--- a/SwiftWisdom/Core/DirectoryManager/DirectoryManager.swift
+++ b/SwiftWisdom/Core/DirectoryManager/DirectoryManager.swift
@@ -16,6 +16,7 @@ public final class DirectoryManager {
     }
 
     private let directoryName: String
+    private let directoryParentPath: FileManager.SearchPathDirectory
     private let fileManager: FileManager
     private let directoryUrl: NSURL
 
@@ -30,11 +31,12 @@ public final class DirectoryManager {
     // MARK: Initializer
 
     // swiftlint:disable force_try
-    public init(directoryName: String, fileManager: FileManager = FileManager.default) {
+    public init(directoryName: String, directoryParentPath: FileManager.SearchPathDirectory = .documentDirectory, fileManager: FileManager = FileManager.default) {
         self.directoryName = directoryName
+        self.directoryParentPath = directoryParentPath
         self.fileManager = fileManager
         // Should fail if not available
-        self.directoryUrl = try! fileManager.directoryPath(withName: directoryName)
+        self.directoryUrl = try! fileManager.directoryPath(withSearchPathDirectory: directoryParentPath, name: directoryName)
     }
     // swiftlint:enable force_try
 
@@ -86,8 +88,8 @@ public final class DirectoryManager {
 }
 
 extension FileManager {
-    fileprivate func directoryPath(withName directoryName: String) throws -> NSURL {
-        let pathsArray = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
+    fileprivate func directoryPath(withSearchPathDirectory searchPathDirectory: SearchPathDirectory, name directoryName: String) throws -> NSURL {
+        let pathsArray = NSSearchPathForDirectoriesInDomains(searchPathDirectory, .userDomainMask, true)
         guard let pathString = pathsArray.first else { fatalError("Unable to create directory") }
         guard let documentsDirectoryPath = NSURL(string: pathString) else {
             throw DirectoryManager.DirectoryError.unableToFindDirectory(name: directoryName)


### PR DESCRIPTION
Allows users of DirectoryManager to (optionally) supply the FileManager.SearchPathDirectory supplied to NSSearchPathForDirectoriesInDomains.

After @adolce's changes in his fork.

I'd like this change to go in along with https://github.com/IntrepidPursuits/swift-wisdom/pull/150 - the project that this change is in aid of requires those changes, as well.
