### PR TITLE
Allow the same version to compile in both Xcode 9 and 10.

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.10.2"
+  s.version       = "0.10.3"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This library is meant to be a general grab bag of Swift methods made by the engi
 The reason for the grab bag approach is to make it easier to facilitate the adding of materials and encourage componentization and sharing of common functionality.
 
 ### Swift Versions
-- Swift 4.0 -> `0.9.0` +
+- Swift 4.1.50 (Xcode 10 Compatible) -> `0.10.3`
+- Swift 4.0 -> `0.9.0` through `0.10.x`
 - Swift 3.2 (Xcode 9 Compatible) -> `0.8.3` through `0.8.4`
 - Swift 3 -> `0.6.1` through `0.8.1`
 - Swift 2 -> anything through `0.5.2`

--- a/SwiftWisdom/Core/Foundation/Data/Data+Extensions.swift
+++ b/SwiftWisdom/Core/Foundation/Data/Data+Extensions.swift
@@ -99,10 +99,14 @@ extension Data {
         return self[ip_safely: idx...idx]
     }
 
+    // Make this compile with both Xcode 9 and Xcode 10's slightly different versions of
+    // Swift 4.1. This can be removed once Xcode 9 is no longer supported.
+    #if !swift(>=4.1.50)
     /// Safer version of `subdata`. Will return nil if the range is outside the bounds of the data.
     public subscript(ip_safely range: CountableRange<Int>) -> Data? {
         return self[ip_safely: Range<Int>(range)]
     }
+    #endif
 
     /// Safer version of `subdata`. Will return nil if the range is outside the bounds of the data.
     public subscript(ip_safely range: CountableClosedRange<Int>) -> Data? {

--- a/SwiftWisdom/Core/StandardLibrary/String/String+Indexing.swift
+++ b/SwiftWisdom/Core/StandardLibrary/String/String+Indexing.swift
@@ -9,12 +9,16 @@ extension String {
         return String(self[indexRange])
     }
 
+    // Make this compile with both Xcode 9 and Xcode 10's slightly different versions of
+    // Swift 4.1. This can be removed once Xcode 9 is no longer supported.
+    #if !swift(>=4.1.50)
     public subscript(range: CountableRange<Int>) -> String {
         let lowerBound = index(startIndex, offsetBy: range.lowerBound)
         let upperBound = index(startIndex, offsetBy: range.upperBound)
         let indexRange = lowerBound..<upperBound
         return String(self[indexRange])
     }
+    #endif
 
     public subscript(range: CountableClosedRange<Int>) -> String {
         let lowerBound = index(startIndex, offsetBy: range.lowerBound)


### PR DESCRIPTION
We have a client with a dependency on swift-wisdom that would like to be able to compile their codebase in both Xcode 9 and 10 simultaneously while they transition.

This conditionally compiles a handful of methods based on either Xcode 10's version of Swift 4.1 (4.1.50) or the existing 4.1.

In Swift 4.1 classic, a separate method signature is required for `CountableRange` because it is its own type.

In Swift 4.1.50, `CountableRange` is aliased to `Range`, so a separate method causes a compile time issue.

Unfortunately there's no way to specify only the additional method in Swift 4.1 classic because the swift version selector only accepts `>`, not `<`, which results in a small amount of duplicated code.