### PR TITLE
Add a Core-App-Extension-Safe subspec

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -34,6 +34,12 @@ Pod::Spec.new do |s|
     cs.dependency 'IP-UIKit-Wisdom', '0.0.10'
   end
 
+  s.subspec "Core-App-Extension-Safe" do |ext|
+    ext.source_files = "SwiftWisdom/Core/**/**/*.swift"
+    ext.exclude_files = "SwiftWisdom/Core/UIKit/UIApplication+Extensions.swift"
+    ext.dependency 'IP-UIKit-Wisdom', '0.0.10'
+  end
+
   s.subspec "Rx" do |rx|
     rx.source_files = "SwiftWisdom/Rx/**/**/*.swift"
     rx.dependency 'RxSwift', '~> 4.0'


### PR DESCRIPTION
NOTE: I'm not certain if THIS is the right thing to do (leave the default spec as EXTENSION-UNSAFE and add a subspec that's extension-safe), 

OR if we should make the default spec EXTENSION-SAFE and add a subspecies to add the UIApplication bits, similar to how people have to add the Rx-related bits separately. This would be a very small breaking change, so we might want it to go into the 0.11.0 release.

-------------

The code in UIApplication+Extensions.swift (with implicit references
to Application.shared) is not safe for use in a Today Widget.
Including it in a project with widgets generates...

EITHER the following compile-time warning:

ld: warning: linking against a dylib which is not safe for use in
application extensions: <path follows>

OR a compile time-error that the methods are marked unavailable,
depending on how Cocoapods generates the project files, especially
with regard to the "Require Only App-Extension-Safe API" setting.

A project has been creating a subspec in a separate branch, but as
it's of general utility, I'd like to move the subspec into the main
branch.