### PR TITLE
Swift 5 Additional Fix - Mathable protocol

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.13.0"
+  s.version       = "0.13.1"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.

--- a/SwiftWisdom/Core/StandardLibrary/Numbers/Mathable.swift
+++ b/SwiftWisdom/Core/StandardLibrary/Numbers/Mathable.swift
@@ -9,18 +9,10 @@
 import Foundation
 import UIKit
 
-public protocol Mathable: Comparable {
-    static func + (lhs: Self, rhs: Self) -> Self
+public protocol Mathable: Comparable, AdditiveArithmetic {
     static func / (lhs: Self, rhs: Self) -> Self
     static func * (lhs: Self, rhs: Self) -> Self
-    static func - (lhs: Self, rhs: Self) -> Self
     init(_ int: Int64)
-}
-
-extension Mathable {
-    public static var zero: Self {
-        return self.init(Int64(0))
-    }
 }
 
 extension Collection where Element: Mathable {

--- a/SwiftWisdomTests/StandardLibrary/Numbers/MathableTests.swift
+++ b/SwiftWisdomTests/StandardLibrary/Numbers/MathableTests.swift
@@ -10,6 +10,21 @@ import XCTest
 import SwiftWisdom
 
 class MathableTests: XCTestCase {
+
+    func testZeroCompatibility() {
+        let _ = Int.zero
+        let _ = Float.zero
+        let _ = Double.zero
+        let _ = CGFloat.zero
+        let _ = UInt.zero
+        let _ = UInt8.zero
+        let _ = UInt16.zero
+        let _ = UInt32.zero
+        let _ = Int8.zero
+        let _ = Int16.zero
+        let _ = Int32.zero
+        let _ = Int64.zero
+    }
     
     func testMean() {
         let maths = [4, 5, 6, 9, 2, 4]


### PR DESCRIPTION
The `Mathable` protocol's `zero` function conflicts with Swift 5's `AdditiveArithmetic` protocol. This PR removes the conflicting method, in favor of the built in one. 

All the classes we conform to `Mathable` by default in our pod implementation also already conform to `AdditiveArithmetic` by Swift. Thus, the convenience methods implemented have the extra `AdditiveArithmetic` requirement now.