### PR TITLE
Fix iterator issue for A6 processors 

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.13.1"
+  s.version       = "0.13.2"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.

--- a/SwiftWisdom/Core/Foundation/Data/Data+Extensions.swift
+++ b/SwiftWisdom/Core/Foundation/Data/Data+Extensions.swift
@@ -142,17 +142,15 @@ extension Data {
 
 extension Data {
     public func ip_segmentIterator(start: Int = 0, chunkLength: Int) -> AnyIterator<Data> {
-        let segmentToWrite = ip_suffix(from: start)
-        var mutable = segmentToWrite
-        let range = 0..<chunkLength
+        var iteratedData = ip_suffix(from: start)
         return AnyIterator {
             let nextData: Data?
-            if let remaining = mutable, remaining.count >= chunkLength {
-                nextData = mutable?[ip_safely:range]
-                mutable?.removeSubrange(range)
-            } else if let remaining = mutable, remaining.count > 0 {
-                nextData = mutable
-                mutable?.count = 0
+            if let remaining = iteratedData, remaining.count >= chunkLength {
+                nextData = remaining.prefix(chunkLength)
+                iteratedData?.removeFirst(chunkLength)
+            } else if let remaining = iteratedData, remaining.count > 0 {
+                nextData = remaining
+                iteratedData?.removeAll()
             } else {
                 nextData = nil
             }


### PR DESCRIPTION
- Apparently optional `Data?` can sometimes return an empty `Data` object on old 32 bit processors (iPhone 5, 5c, iPad 4). You can see for yourself if you run the unit tests in Xcode 10.2 on iPhone 5 simulator.
- I don't know why and I don't exactly know how. But this seems to fix it.
- It also reads a little better.
- There may be other places where changes like this are needed as well, but I haven't seen them.