### PR TITLE
Update .swiftlint.yml to latest Intrepid version and clean up resulting issues

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,5 @@
+# Compiled with 0.30.1 rules
+
 # Don't add any files/directories to the 'include:' section. Everything not
 # listed under 'excluded:' should be linted.
 # included:
@@ -14,6 +16,7 @@ reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)
 
 # enabled_rules_for_documentation:
 #   - attributes
+#   - block_based_kvo
 #   - class_delegate_protocol
 #   - closing_brace
 #   - closure_end_indentation
@@ -22,41 +25,54 @@ reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)
 #   - colon
 #   - comma
 #   - compiler_protocol_init
+#   - contains_over_first_not_nil
 #   - control_statement
 #   - custom_rules
 #   - discarded_notification_center_observer
+#   - discouraged_direct_init
+#   - duplicate_imports
 #   - dynamic_inline
 #   - empty_parameters
 #   - empty_parentheses_with_trailing_closure
+#   - fallthrough
+#   - file_length
 #   - first_where
 #   - force_cast
 #   - force_try
 #   - force_unwrapping
 #   - generic_type_name
-#   - identifier
+#   - is_disjoint
+#   - identifier_name
+#   - inert_defer
 #   - implicit_getter
 #   - implicitly_unwrapped_optional
 #   - leading_whitespace
 #   - legacy_cggeometry_functions
 #   - legacy_constant
 #   - legacy_constructor
+#   - legacy_hashing
 #   - legacy_nsgeometry_functions
 #   - mark
-#   - missing_docs
 #   - nesting
 #   - notification_center_detachment
+#   - no_fallthrough_only
 #   - object_literal
 #   - opening_brace
 #   - operator_usage_whitespace
 #   - operator_whitespace
 #   - private_outlet
 #   - private_unit_test
+#   - protocol_property_accessors_order
 #   - redundant_discardable_let
 #   - redundant_nil_coalescing
+#   - redundant_objc_attribute
 #   - redundant_optional_initialization
+#   - redundant_set_access_control
 #   - redundant_string_enum_value
 #   - return_arrow_whitespace
 #   - statement_position
+#   - superfluous_disable_command
+#   - switch_case_alignment
 #   - syntactic_sugar
 #   - trailing_comma
 #   - trailing_newline
@@ -64,42 +80,113 @@ reporter: "xcode" # reporter type (xcode, json, csv, checkstyle, junit)
 #   - trailing_whitespace
 #   - type_body_length
 #   - type_name
+#   - unneeded_break_in_switch
 #   - unused_closure_parameter
+#   - unused_control_flow_label
 #   - unused_enumerated
 #   - unused_optional_binding
-#   - valid_docs
+#   - unused_setter_value
 #   - valid_ibinspectable
 #   - vertical_parameter_alignment
 #   - vertical_whitespace
 #   - weak_delegate
+#   - xctfail_message
 
 opt_in_rules:
+  - anyobject_protocol
+  - closure_body_length
+  - collection_alignment
+  - convenience_type
+  - empty_xctest_method
   - explicit_init
   - fatal_error_message
+  - function_default_parameter_at_end
+  - identical_operands
+  - joined_default_parameter
+  - legacy_random
+  - lower_acl_than_parent
+  - multiline_arguments
+  - multiline_function_chains
+  - multiline_parameters
+  - nslocalizedstring_key
   - overridden_super_call
   - prohibited_super_call
   - redundant_void_return
+  - sorted_first_last
+  - static_operator
+  - strong_iboutlet
+  - unavailable_function
+  - unused_import
+  - unused_private_declaration
+  - vertical_parameter_alignment_on_call
+  - xct_specific_matcher
 
 disabled_rules:
+  - array_init
   - conditional_returns_on_newline
   - cyclomatic_complexity
+  - discouraged_object_literal
+  - discouraged_optional_boolean
+  - discouraged_optional_collection
   - empty_count
+  - empty_enum_arguments
+  - empty_string
+  - explicit_acl
+  - explicit_enum_raw_value
+  - explicit_self
+  - explicit_top_level_acl
   - explicit_type_interface
+  - extension_access_modifier
   - file_header
+  - file_name
   - for_where
+  - implicit_return
+  - let_var_whitespace
+  - missing_docs
+  - multiline_arguments_brackets
+  - multiline_literal_brackets
+  - multiline_parameters_brackets
   - nimble_operator
+  - no_extension_access_modifier
+  - no_grouping_extension
+  - number_separator
+  - override_in_extension
+  - pattern_matching_keywords
+  - prefixed_toplevel_constant
+  - private_action
+  - private_over_fileprivate
+  - prohibited_interface_builder
+  - quick_discouraged_call
+  - quick_discouraged_focused_test
+  - quick_discouraged_pending_test
+  - redundant_type_annotation
+  - required_enum_case
+  - single_test_class
+  - sorted_imports
   - shorthand_operator
+  - strict_fileprivate
   - switch_case_on_newline
   - todo
+  - toggle_bool
+  - trailing_closure
+  - unneeded_parentheses_in_closure_argument
+  - untyped_error_in_catch
+  - vertical_whitespace_between_cases
   - void_return
-  - identifier_name
+  - yoda_condition
 
-  # These next four rules are recommended to be enabled on a project-by-project
+  # These next rules are recommended to be enabled on a project-by-project
   # basis with specific configurations that fit the project style.
   - function_body_length
   - function_parameter_count
   - large_tuple
+  - last_where
   - line_length
+  - literal_expression_end_indentation
+  - modifier_order
+  - multiple_closures_with_trailing_closure
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
 
 ## Rule Configuration
 
@@ -110,12 +197,12 @@ file_length:
   warning: 750
   error: 1500
 
+identifier_name:
+  excluded:
+    - id
+
+lower_acl_than_parent:
+  severity: error
+
 nesting:
   type_level: 3
-
-identifier_name:
-  allowed_symbols: _
-  min_length: 2
-
-type_name:
-  min_length: 2

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -198,8 +198,16 @@ file_length:
   error: 1500
 
 identifier_name:
+  allowed_symbols: "_"
+  min_length: 2
   excluded:
     - id
+    - r
+    - g
+    - b
+    - a
+    - x
+    - y
 
 lower_acl_than_parent:
   severity: error

--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.13.2"
+  s.version       = "0.13.3"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.

--- a/SwiftWisdom/AppDelegate.swift
+++ b/SwiftWisdom/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/SwiftWisdom/Core/Async/Qu/Qu.swift
+++ b/SwiftWisdom/Core/Async/Qu/Qu.swift
@@ -16,7 +16,9 @@ public typealias CompletableBlock = (@escaping Block) -> ()
 
 // MARK: Qu
 
+//swiftlint:disable type_name
 public class Qu {
+//swiftlint:enable type_name
 
     // MARK: Priority Enumeration
 

--- a/SwiftWisdom/Core/CommonTypes/Multicast.swift
+++ b/SwiftWisdom/Core/CommonTypes/Multicast.swift
@@ -25,7 +25,7 @@ public struct Weak<T> where T: AnyObject {
     Only subclasses of NSObject can conform to this protocol. In addition, you can only typealias `MulticastDelegate` to a
     class or an `@objc` protocol.
  */
-public protocol Multicast: class {
+public protocol Multicast: AnyObject {
 
     associatedtype MulticastDelegate: AnyObject
 

--- a/SwiftWisdom/Core/Controls/VideoPlayer.swift
+++ b/SwiftWisdom/Core/Controls/VideoPlayer.swift
@@ -69,7 +69,7 @@ extension Video {
 
 // MARK: Player
 
-public protocol VideoPlayerDelegate: class {
+public protocol VideoPlayerDelegate: AnyObject {
     /**
      The delegate is notified when the video finishes playing and returns 
      a boolean whether or not the video should repeat
@@ -109,6 +109,7 @@ public final class VideoPlayer: UIViewController {
         setupItemNotification(item)
     }
 
+    @available(*, unavailable)
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/SwiftWisdom/Core/DirectoryManager/DirectoryManager.swift
+++ b/SwiftWisdom/Core/DirectoryManager/DirectoryManager.swift
@@ -59,6 +59,7 @@ public final class DirectoryManager {
         return ((try? data.write(to: URL(fileURLWithPath: path), options: [.atomicWrite])) != nil)
     }
 
+    //swiftlint:disable function_default_parameter_at_end
     public func writeInBackground(_ data: Data, withName name: String = UUID().uuidString, completion: @escaping (String, Bool) -> Void = { _, _  in }) {
         Background {
             let success = self.write(data, withName: name)
@@ -67,6 +68,7 @@ public final class DirectoryManager {
             }
         }
     }
+    //swiftlint:enable function_default_parameter_at_end
 
     // MARK: Delete
 

--- a/SwiftWisdom/Core/Foundation/Data/Data+Extensions.swift
+++ b/SwiftWisdom/Core/Foundation/Data/Data+Extensions.swift
@@ -141,6 +141,7 @@ extension Data {
 }
 
 extension Data {
+    //swiftlint:disable function_default_parameter_at_end
     public func ip_segmentIterator(start: Int = 0, chunkLength: Int) -> AnyIterator<Data> {
         var iteratedData = ip_suffix(from: start)
         return AnyIterator {
@@ -157,4 +158,5 @@ extension Data {
             return nextData
         }
     }
+    //swiftlint:enable function_default_parameter_at_end
 }

--- a/SwiftWisdom/Core/Foundation/Not.swift
+++ b/SwiftWisdom/Core/Foundation/Not.swift
@@ -11,6 +11,9 @@
  
       let newNames = ["Joe", "Betty"].filter(!existingNames.contains)
  */
+
+//swiftlint:disable static_operator
 public prefix func ! <T>(original: @escaping (T) -> Bool) -> (T) -> Bool {
     return { !original($0) }
 }
+//swiftlint:enable static_operator

--- a/SwiftWisdom/Core/StandardLibrary/Array/Sequence+Utilities.swift
+++ b/SwiftWisdom/Core/StandardLibrary/Array/Sequence+Utilities.swift
@@ -79,7 +79,7 @@ extension Sequence where Iterator.Element: Equatable {
     ///
     /// - returns: `true` if the sequence contains `all`
     public func ip_contains<T: Sequence>(all: T) -> Bool where T.Iterator.Element == Iterator.Element {
-        for e in all where !contains(e) {
+        for element in all where !contains(element) {
             return false
         }
         return true

--- a/SwiftWisdom/Core/StandardLibrary/Numbers/UnsignedInteger+Extensions.swift
+++ b/SwiftWisdom/Core/StandardLibrary/Numbers/UnsignedInteger+Extensions.swift
@@ -11,17 +11,14 @@ import Foundation
 extension UnsignedInteger {
     public static func ip_random() -> Self {
         let intMax = Int(Int64(ip_maxValue))
-        let rand = random(inRange: 0...intMax)
+        let rand = Int.random(in: 0...intMax)
         return self.init(ip_safely: rand)
     }
 }
 
-// TODO: evaluate whether we should move random to be a member of CountableClosedRange
+@available(*, deprecated, message: "Use Int.random(in:) instead", renamed: "Int.random(in:)")
 public func random(inRange range: CountableClosedRange<Int>) -> Int {
-    let diff = range.upperBound - range.lowerBound
-    let randomOffset = Int(arc4random_uniform(UInt32(diff + 1)))
-    let random = range.lowerBound + randomOffset
-    return random
+    return Int.random(in: range)
 }
 
 // TODO: write tests for this extension

--- a/SwiftWisdom/Core/StandardLibrary/String/String+Data.swift
+++ b/SwiftWisdom/Core/StandardLibrary/String/String+Data.swift
@@ -17,8 +17,8 @@ extension String {
 
         var data = Data(capacity: trimmed.count / 2)
 
-        for i in stride(from: 0, through: trimmed.count - 2, by: 2) {
-            let byteString = trimmed[i...i + 1]
+        for step in stride(from: 0, through: trimmed.count - 2, by: 2) {
+            let byteString = trimmed[step...step + 1]
             var byte = UInt8(byteString.ip_hexInt)
             data.append(&byte, count: MemoryLayout<UInt8>.size)
         }

--- a/SwiftWisdom/Core/StandardLibrary/String/String+Localization.swift
+++ b/SwiftWisdom/Core/StandardLibrary/String/String+Localization.swift
@@ -2,7 +2,9 @@ import Foundation
 
 extension String {
     public func ip_localized(_ args: [CVarArg] = [], comment: String = "") -> String {
+        //swiftlint:disable nslocalizedstring_key
         let localizedFormat = NSLocalizedString(self, comment: comment)
+        //swiftlint:enable nslocalizedstring_key
         return String(format: localizedFormat, arguments: args)
     }
 }

--- a/SwiftWisdom/Core/UIKit/CoreAnimation/BasicVerticalGradientLayer.swift
+++ b/SwiftWisdom/Core/UIKit/CoreAnimation/BasicVerticalGradientLayer.swift
@@ -18,6 +18,7 @@ public final class BasicVerticalGradientLayer: CAGradientLayer {
         colors = [topColor.cgColor, bottomColor.cgColor]
     }
 
+    @available(*, unavailable)
     required public init(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/SwiftWisdom/Core/UIKit/PercentAnimator/PercentAnimator.swift
+++ b/SwiftWisdom/Core/UIKit/PercentAnimator/PercentAnimator.swift
@@ -52,7 +52,7 @@ private final class PercentAnimator {
 
     private static let shared = PercentAnimator()
 
-    static func animateWithDuration(
+    fileprivate static func animateWithDuration(
         _ duration: TimeInterval,
         animation: @escaping (AnimationState) -> Void) {
             let id = UUID().uuidString

--- a/SwiftWisdom/Core/UIKit/UIButton+AttributedTitle.swift
+++ b/SwiftWisdom/Core/UIKit/UIButton+AttributedTitle.swift
@@ -10,6 +10,7 @@ import UIKit
 
 public extension UIButton {
 
+    //swiftlint:disable function_default_parameter_at_end
     /**
      This will use existing attributes on the attributed text, plus the spacing passed in and apply 
      them to the string passed in.
@@ -30,4 +31,5 @@ public extension UIButton {
         }
         setAttributedTitle(spacedText, for: state)
     }
+    //swiftlint:enable function_default_parameter_at_end
 }

--- a/SwiftWisdom/Core/UIKit/UIView+Nib.swift
+++ b/SwiftWisdom/Core/UIKit/UIView+Nib.swift
@@ -13,11 +13,14 @@ public extension UIView {
         return ip_fromNib(nibNameOrNil, type: self)
     }
 
+    //swiftlint:disable function_default_parameter_at_end
     class func ip_fromNib<T: UIView>(_ nibNameOrNil: String? = nil, type: T.Type) -> T {
-        let v: T? = ip_fromNib(nibNameOrNil, type: T.self)
-        return v!
+        let view: T? = ip_fromNib(nibNameOrNil, type: T.self)
+        return view!
     }
+    //swiftlint:enable function_default_parameter_at_end
 
+    //swiftlint:disable function_default_parameter_at_end
     class func ip_fromNib<T: UIView>(_ nibNameOrNil: String? = nil, type: T.Type) -> T? {
         var view: T?
         let name: String
@@ -28,13 +31,14 @@ public extension UIView {
             name = ip_nibName
         }
         let nibViews = Bundle.main.loadNibNamed(name, owner: nil, options: nil)
-        for v in nibViews ?? [] {
-            if let tog = v as? T {
+        for thisView in nibViews ?? [] {
+            if let tog = thisView as? T {
                 view = tog
             }
         }
         return view
     }
+    //swiftlint:enable function_default_parameter_at_end
 
     class var ip_nibName: String {
         let name = "\(self)".components(separatedBy: ".").first ?? ""

--- a/SwiftWisdom/Rx/Rx+Extensions.swift
+++ b/SwiftWisdom/Rx/Rx+Extensions.swift
@@ -9,6 +9,8 @@
 import RxSwift
 import RxCocoa
 
+//swiftlint:disable static_operator
+
 precedencegroup Binding {
     associativity: left
     higherThan: Disposing


### PR DESCRIPTION
This updates our two-year-old .swiftlint.yml to the latest version in https://github.com/IntrepidPursuits/swift-style-guide/blob/master/.swiftlint.yml , and cleans up the resulting warnings and errors.

I've created this PR with each class of warning or error handled in a separate commit, for ease of review. When I merge, I plan to squash all of the code changes down into one commit.