### PR TITLE
Make the pod iPhone extension-compliant

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.13.3"
+  s.version       = "0.14.0"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.

--- a/SwiftWisdom/Core/UIKit/UIApplication+Extensions.swift
+++ b/SwiftWisdom/Core/UIKit/UIApplication+Extensions.swift
@@ -13,10 +13,14 @@ enum OpenSettingsError: Error {
 }
 
 extension UIApplication {
+
+    @available(*, unavailable, message: "Call open(_:) directly using UIApplication.openSettingsURLString.\nSee ip_openSettingsApp source code for more details.")
     public func ip_openSettingsApp() throws {
+        #if false
         guard let url = URL(string: UIApplication.openSettingsURLString), canOpenURL(url) else {
             throw OpenSettingsError.cannotOpenURL
         }
         open(url)
+        #endif
     }
 }


### PR DESCRIPTION
The pod contains a reference to `UIApplication.open(_:)`, which is not permitted for Extensions (such as "Today Widgets"). For reasons I don't understand, Xcode 10 allowed my app *and* its extension, both of which rely heavily on this pod, to compile. But now, Xcode 11 is correctly preventing the extension from compiling do to the presence of this call.

I see three potential solutions:

1. The one in this PR. Requires major version bump. Simply remove the offending function call, and mark the one function that uses it as `unavailable` at compile-time (and provide a good error message). Since the function that is being made unavailable is small (3 or 4 lines of code), well-known, easily searchable, and available in the pod source (`#ifdef`'d out), this should be a minimal burden on pod clients.
2. Requires major version bump. Move the offending call to a separate directory, and out of the "core" spec. Create a separate subspec to contain the "app-only functionality." Since this would, at present, contain ONE three-line function, this seems like overkill. Further, while option (1) can be self-documenting with its errors, option (2) can't be. We can't have an `unavailable` version in the core spec and an available version in the subspec.
3. Requires minor version bump, but then requires downstream pods to change. Move the offending call to a separate directory, but leave it in the "core" spec, leaving the core spec as app-only. Create a separate subspec to expose the "extension-only" subset (everything except this one function). As I said above, this would require only a minor update to *this* pod, but any downstream podspecs that rely on *this* pod would need to change to include only the "extension-only" subset. IMO that's more trouble than it's worth for this single function.