### PR TITLE
Fix bug in ip_fromNib()

### DIFF
--- a/SwiftWisdom/Core/UIKit/UIView+Nib.swift
+++ b/SwiftWisdom/Core/UIKit/UIView+Nib.swift
@@ -9,18 +9,15 @@
 import UIKit
 
 public extension UIView {
-    class func ip_fromNib<T: UIView>(_ nibNameOrNil: String? = nil, type: T.Type = T.self, in bundle: Bundle = Bundle.main) -> T {
-        return ip_fromNib(nibNameOrNil, type: type, in: bundle)!
-    }
-
-    //swiftlint:disable function_default_parameter_at_end
-    class func ip_fromNib<T: UIView>(_ nibNameOrNil: String? = nil, type: T.Type, in bundle: Bundle = Bundle.main) -> T? {
+    class func ip_fromNib(_ nibNameOrNil: String? = nil, in bundle: Bundle = Bundle.main) -> Self {
         // Most nibs are demangled by practice, if not, just declare string explicitly
         let name = nibNameOrNil ?? ip_nibName
         let nibViews = bundle.loadNibNamed(name, owner: nil, options: nil)
-        return nibViews?.first(where: { $0 is T }) as? T
+        guard let view = nibViews?.first as? Self else {
+            fatalError("No nib with name \(name) found in bundle: \(bundle).")
+        }
+        return view
     }
-    //swiftlint:enable function_default_parameter_at_end
 
     class var ip_nibName: String {
         let name = "\(self)".components(separatedBy: ".").first ?? ""

--- a/SwiftWisdomTests/UIKit/UIViewTests/UIViewTests.swift
+++ b/SwiftWisdomTests/UIKit/UIViewTests/UIViewTests.swift
@@ -13,18 +13,8 @@ import XCTest
 final class UIViewTests: XCTestCase {
     let bundle = Bundle(for: TestView.self)
 
-    func test_ip_fromNib_returnsNonOptional() {
+    func test_ip_fromNib_returnsCorrectViewType() {
         let testView = TestView.ip_fromNib(in: bundle)
-        XCTAssert(testView is TestView)
+        XCTAssert(testView.isKind(of: TestView.self))
     }
-
-    func test_ip_fromNib_returnsOptional() {
-        guard let testView = TestView.ip_fromNib(type: TestView.self, in: bundle) else {
-            XCTFail("Failed to load from nib")
-            return
-        }
-        XCTAssertNotNil(testView)
-    }
-
-
 }


### PR DESCRIPTION
This PR fixes the "fix" I made in the previous PR. My aim way to simplify the logic of the `ip_fromNib` function, which looked pretty ungainly. Here I take this one step further and completely do away with the optionality of this function. The optionality was a bit of a false-friend to begin with, as `Bundle.loadNibNamed(:owner:options:)` actually throws a runtime error if it can't find a nib instead of returning an empty array. I've tested this in a sample app, and I'm reasonable sure that it works with all, some or none of the optional parameters, at least for the testing I did.